### PR TITLE
fix: should keep support *.json ext to detect response type

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,6 +143,10 @@ function accepts(ctx) {
   if (ctx.accepts('html', 'text', 'json') === 'json') {
     return 'json';
   }
+  // request url match *.json
+  if (ctx.path.endsWith('.json')) {
+    return 'json';
+  }
   return 'html';
 }
 

--- a/test/fixtures/onerror/app/router.js
+++ b/test/fixtures/onerror/app/router.js
@@ -4,5 +4,6 @@ module.exports = app => {
   app.get('/', app.controller.home.index);
   app.get('/csrf', app.controller.home.csrf);
   app.post('/test', app.controller.home.test);
+  app.get('/user', app.controller.user);
   app.get('/user.json', app.controller.user);
 };

--- a/test/onerror.test.js
+++ b/test/onerror.test.js
@@ -69,12 +69,27 @@ describe('test/onerror.test.js', () => {
     .expect(400);
   });
 
-  it('should return err.stack', () => {
+  it('should return error json format when Accept is json', () => {
     return request(app.callback())
-    .get('/user.json')
-    .set('Accept', 'application/json')
-    .expect(/"message":"test error","stack":/)
-    .expect(500);
+      .get('/user')
+      .set('Accept', 'application/json')
+      .expect(res => {
+        assert(res.body);
+        assert(res.body.message === 'test error');
+        assert(res.body.stack.includes('Error: test error'));
+      })
+      .expect(500);
+  });
+
+  it('should return error json format when request path match *.json', () => {
+    return request(app.callback())
+      .get('/user.json')
+      .expect(res => {
+        assert(res.body);
+        assert(res.body.message === 'test error');
+        assert(res.body.stack.includes('Error: test error'));
+      })
+      .expect(500);
   });
 
   it('should support custom accpets return err.stack', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
