### PR TITLE
feat: allow customize isProd function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: node_js
 node_js:
   - '8'
   - '9'
+before_install:
+  - npm i npminstall -g
 install:
-  - npm i npminstall && npminstall
+  - npminstall
 script:
   - npm run ci
 after_script:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ npm i egg-onerror
 - `text: Function` - customize text error handler.
 - `json: Function` - customize json error handler.
 - `jsonp: Function` - customize jsonp error handler.
+- `isProd: Function` - customize logic to detect if app is running on production environment. [Example](./test/fixtures/onerror-custom-isProd/config/config.default.js#L4)
 
 ```js
 // config.default.js

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,8 +3,8 @@
 exports.detectErrorMessage = function(ctx, err) {
   // detect json parse error
   if (err.status === 400 &&
-      err.name === 'SyntaxError' &&
-      ctx.request.is('application/json', 'application/vnd.api+json', 'application/csp-report')) {
+    err.name === 'SyntaxError' &&
+    ctx.request.is('application/json', 'application/vnd.api+json', 'application/csp-report')) {
     return 'Problems parsing JSON';
   }
   return err.message;
@@ -27,5 +27,11 @@ exports.accepts = function(ctx) {
 };
 
 exports.isProd = function(app) {
-  return app.config.env !== 'local' && app.config.env !== 'unittest';
+  let isProd = function(app) { return app.config.env !== 'local' && app.config.env !== 'unittest'; };
+
+  if (app.config.onerror && (typeof app.config.onerror.isProd === 'function')) {
+    isProd = app.config.onerror.isProd;
+  }
+
+  return isProd(app);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11086 @@
+{
+  "name": "egg-onerror",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.taobao.org/@babel/code-frame/download/@babel/code-frame-7.5.5.tgz",
+      "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.taobao.org/@babel/generator/download/@babel/generator-7.5.5.tgz",
+      "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.5.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-2.5.2.tgz",
+          "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "http://registry.npm.taobao.org/@babel/helper-function-name/download/@babel/helper-function-name-7.1.0.tgz",
+      "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "http://registry.npm.taobao.org/@babel/helper-get-function-arity/download/@babel/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npm.taobao.org/@babel/helper-split-export-declaration/download/@babel/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npm.taobao.org/@babel/highlight/download/@babel/highlight-7.5.0.tgz",
+      "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npm.taobao.org/js-tokens/download/js-tokens-4.0.0.tgz",
+          "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.taobao.org/@babel/parser/download/@babel/parser-7.5.5.tgz",
+      "integrity": "sha1-AvB3rIgX099Kgy71neZ1Zeccyks=",
+      "dev": true
+    },
+    "@babel/runtime": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.taobao.org/@babel/runtime/download/@babel/runtime-7.5.5.tgz",
+      "integrity": "sha1-dPulbTXvvspEQJHHhQzNSU/S8TI=",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.13.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregenerator-runtime%2Fdownload%2Fregenerator-runtime-0.13.3.tgz",
+          "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npm.taobao.org/@babel/template/download/@babel/template-7.4.4.tgz",
+      "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.taobao.org/@babel/traverse/download/@babel/traverse-7.5.5.tgz?cache=0&sync_timestamp=1563399350354&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40babel%2Ftraverse%2Fdownload%2F%40babel%2Ftraverse-7.5.5.tgz",
+      "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npm.taobao.org/globals/download/globals-11.12.0.tgz?cache=0&sync_timestamp=1563721993391&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobals%2Fdownload%2Fglobals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.taobao.org/@babel/types/download/@babel/types-7.5.5.tgz",
+      "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
+    "@eggjs/router": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/@eggjs/router/download/@eggjs/router-2.0.0.tgz",
+      "integrity": "sha1-mxZN2dbZcIFQLl/cd6c0NZUTYYo=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "debug": "^3.1.0",
+        "http-errors": "^1.3.1",
+        "inflection": "^1.12.0",
+        "is-type-of": "^1.2.1",
+        "koa-compose": "^3.0.0",
+        "koa-convert": "^1.2.0",
+        "methods": "^1.0.1",
+        "path-to-regexp": "^1.1.1",
+        "urijs": "^1.19.0",
+        "utility": "^1.15.0"
+      }
+    },
+    "@jest/types": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npm.taobao.org/@jest/types/download/@jest/types-24.8.0.tgz",
+      "integrity": "sha1-8x4llIxY8KvYyEWuJvzqFJHep60=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^12.0.9"
+      }
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "http://registry.npm.taobao.org/@mrmlnc/readdir-enhanced/download/@mrmlnc/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npm.taobao.org/@nodelib/fs.stat/download/@nodelib/fs.stat-1.1.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40nodelib%2Ffs.stat%2Fdownload%2F%40nodelib%2Ffs.stat-1.1.3.tgz",
+      "integrity": "sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs=",
+      "dev": true
+    },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npm.taobao.org/@types/accepts/download/@types/accepts-1.3.5.tgz?cache=0&sync_timestamp=1563338358883&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Faccepts%2Fdownload%2F%40types%2Faccepts-1.3.5.tgz",
+      "integrity": "sha1-w0vsEVz8dG4E/loFnfTOfns5FXU=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/body-parser": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npm.taobao.org/@types/body-parser/download/@types/body-parser-1.17.0.tgz",
+      "integrity": "sha1-n1ydm9BLtUvjLV65/A2Ml05s9Yw=",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npm.taobao.org/@types/connect/download/@types/connect-3.4.32.tgz",
+      "integrity": "sha1-qg6WFrlDXMrQK8UrW0VP/Cxwuig=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cookies": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npm.taobao.org/@types/cookies/download/@types/cookies-0.7.2.tgz",
+      "integrity": "sha1-XgVg1G7ZmYCC3OeZrxBY3WpJeAo=",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/dargs": {
+      "version": "5.1.0",
+      "resolved": "http://registry.npm.taobao.org/@types/dargs/download/@types/dargs-5.1.0.tgz",
+      "integrity": "sha1-BuLJQ9rbkWeWcAX/1GelgaAJ00c=",
+      "dev": true
+    },
+    "@types/depd": {
+      "version": "1.1.32",
+      "resolved": "https://registry.npm.taobao.org/@types/depd/download/@types/depd-1.1.32.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fdepd%2Fdownload%2F%40types%2Fdepd-1.1.32.tgz",
+      "integrity": "sha1-eTf2aHDQzXqYgRUuTrAsjEMpjxE=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/empower": {
+      "version": "1.2.30",
+      "resolved": "http://registry.npm.taobao.org/@types/empower/download/@types/empower-1.2.30.tgz",
+      "integrity": "sha1-x8/BSzph5Ux0xnTB+8kbot8NE5I=",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.taobao.org/@types/events/download/@types/events-3.0.0.tgz",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
+      "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npm.taobao.org/@types/express/download/@types/express-4.17.0.tgz?cache=0&sync_timestamp=1559682327408&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fexpress%2Fdownload%2F%40types%2Fexpress-4.17.0.tgz",
+      "integrity": "sha1-SertsglYKobxLtm3JRYPEtBO8oc=",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.7",
+      "resolved": "https://registry.npm.taobao.org/@types/express-serve-static-core/download/@types/express-serve-static-core-4.16.7.tgz",
+      "integrity": "sha1-ULpvimkcCKPdn6f7ol7zEz0pgEk=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npm.taobao.org/@types/glob/download/@types/glob-7.1.1.tgz",
+      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npm.taobao.org/@types/http-assert/download/@types/http-assert-1.5.0.tgz?cache=0&sync_timestamp=1562620918481&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fhttp-assert%2Fdownload%2F%40types%2Fhttp-assert-1.5.0.tgz",
+      "integrity": "sha1-VslcabUecWiw1nJwBdH7KgCq75Q=",
+      "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npm.taobao.org/@types/istanbul-lib-coverage/download/@types/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha1-QplbRG25pIoRoH7Ag0mahg6ROP8=",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npm.taobao.org/@types/istanbul-lib-report/download/@types/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha1-5Ucef6M8YTWN04QmGJwDelhDO4w=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npm.taobao.org/@types/istanbul-reports/download/@types/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha1-eoy/akBvNsit2HFiWyeOrwsNJVo=",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/keygrip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/@types/keygrip/download/@types/keygrip-1.0.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fkeygrip%2Fdownload%2F%40types%2Fkeygrip-1.0.1.tgz",
+      "integrity": "sha1-/1QEYtL7TQqIRBzq8n0oewHD2Hg=",
+      "dev": true
+    },
+    "@types/koa": {
+      "version": "2.0.49",
+      "resolved": "https://registry.npm.taobao.org/@types/koa/download/@types/koa-2.0.49.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fkoa%2Fdownload%2F%40types%2Fkoa-2.0.49.tgz",
+      "integrity": "sha1-j/wt291xWiw5KiGMZ+EWywcAcjQ=",
+      "dev": true,
+      "requires": {
+        "@types/accepts": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/koa-compose": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npm.taobao.org/@types/koa-compose/download/@types/koa-compose-3.2.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fkoa-compose%2Fdownload%2F%40types%2Fkoa-compose-3.2.4.tgz",
+      "integrity": "sha1-dqRhY0pZw+E0SYMXCLubNV+xVI4=",
+      "dev": true,
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/koa-router": {
+      "version": "7.0.42",
+      "resolved": "https://registry.npm.taobao.org/@types/koa-router/download/@types/koa-router-7.0.42.tgz",
+      "integrity": "sha1-DlwB1NCihz1ALUMhFPCDctfFDrE=",
+      "dev": true,
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/@types/mime/download/@types/mime-2.0.1.tgz",
+      "integrity": "sha1-3EiIQjEqfwdRSTEpBbXjwLBUx50=",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npm.taobao.org/@types/minimatch/download/@types/minimatch-3.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fminimatch%2Fdownload%2F%40types%2Fminimatch-3.0.3.tgz",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "8.10.51",
+      "resolved": "https://registry.npm.taobao.org/@types/node/download/@types/node-8.10.51.tgz?cache=0&sync_timestamp=1565214337285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fnode%2Fdownload%2F%40types%2Fnode-8.10.51.tgz",
+      "integrity": "sha1-gGAIV8Ckeo6Lr8La5trtbbWONic=",
+      "dev": true
+    },
+    "@types/power-assert": {
+      "version": "1.5.0",
+      "resolved": "http://registry.npm.taobao.org/@types/power-assert/download/@types/power-assert-1.5.0.tgz",
+      "integrity": "sha1-TMQ3FxJ82BkBVV+QXFXwKTgSDcs=",
+      "dev": true,
+      "requires": {
+        "@types/empower": "*",
+        "@types/power-assert-formatter": "*"
+      }
+    },
+    "@types/power-assert-formatter": {
+      "version": "1.4.28",
+      "resolved": "http://registry.npm.taobao.org/@types/power-assert-formatter/download/@types/power-assert-formatter-1.4.28.tgz",
+      "integrity": "sha1-Jbj922MiJZxrkcNTONObD45SQlI=",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "http://registry.npm.taobao.org/@types/range-parser/download/@types/range-parser-1.2.3.tgz",
+      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw=",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "http://registry.npm.taobao.org/@types/serve-static/download/@types/serve-static-1.13.2.tgz",
+      "integrity": "sha1-9axNemQgqZpqRa9HGfTc2M2Qekg=",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
+    "@types/urllib": {
+      "version": "2.33.0",
+      "resolved": "http://registry.npm.taobao.org/@types/urllib/download/@types/urllib-2.33.0.tgz",
+      "integrity": "sha1-8folAGa9BwaV6WGtgPstCYqPbt4=",
+      "dev": true,
+      "requires": {
+        "urllib": "*"
+      }
+    },
+    "@types/yargs": {
+      "version": "12.0.12",
+      "resolved": "https://registry.npm.taobao.org/@types/yargs/download/@types/yargs-12.0.12.tgz",
+      "integrity": "sha1-Rd0dBjjoyPFT6H0paQdlkpaHORY=",
+      "dev": true
+    },
+    "a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/a-sync-waterfall/download/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha1-dba2qnJZi0l6El56J3DxT0yKH6c=",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npm.taobao.org/accepts/download/accepts-1.3.7.tgz",
+      "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "acorn": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-5.7.3.tgz",
+      "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
+      "dev": true
+    },
+    "acorn-es7-plugin": {
+      "version": "1.1.7",
+      "resolved": "http://registry.npm.taobao.org/acorn-es7-plugin/download/acorn-es7-plugin-1.1.7.tgz",
+      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s=",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npm.taobao.org/acorn-jsx/download/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "address": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npm.taobao.org/address/download/address-1.1.0.tgz",
+      "integrity": "sha1-744EeEf80sW29QwWll+ST9mf5wk=",
+      "dev": true
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npm.taobao.org/agent-base/download/agent-base-4.3.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fagent-base%2Fdownload%2Fagent-base-4.3.0.tgz",
+      "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "agentkeepalive": {
+      "version": "4.0.2",
+      "resolved": "http://registry.npm.taobao.org/agentkeepalive/download/agentkeepalive-4.0.2.tgz",
+      "integrity": "sha1-OKSQt3mpe9VC0VPlp9oNH97zXdM=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npm.taobao.org/ajv/download/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npm.taobao.org/ajv-keywords/download/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/amdefine/download/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npm.taobao.org/ansi-colors/download/ansi-colors-3.2.4.tgz",
+      "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npm.taobao.org/ansi-escapes/download/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-2.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/any-promise/download/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fanymatch%2Fdownload%2Fanymatch-2.0.0.tgz",
+      "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "http://registry.npm.taobao.org/normalize-path/download/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "http://registry.npm.taobao.org/argparse/download/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/aria-query/download/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "http://registry.npm.taobao.org/arr-diff/download/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/arr-flatten/download/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/arr-union/download/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/array-differ/download/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/array-filter/download/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
+    "array-find": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/array-find/download/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "http://registry.npm.taobao.org/array-includes/download/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npm.taobao.org/array-union/download/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/array-uniq/download/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "http://registry.npm.taobao.org/array-unique/download/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/arrify/download/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "http://registry.npm.taobao.org/asap/download/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/assign-symbols/download/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npm.taobao.org/ast-types/download/ast-types-0.13.2.tgz",
+      "integrity": "sha1-3zm2d6kRqD86BJZE+3T93tI86kg=",
+      "dev": true
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "http://registry.npm.taobao.org/ast-types-flow/download/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/async-each/download/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npm.taobao.org/asynckit/download/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/atob/download/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+      "dev": true
+    },
+    "autod": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/autod/download/autod-3.1.0.tgz",
+      "integrity": "sha1-Xicni4aLihOwpLbzBOpQung/KOk=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-preset-env": "^1.6.1",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-0": "^6.24.1",
+        "co": "^4.6.0",
+        "colors": "^1.1.2",
+        "commander": "^2.11.0",
+        "crequire": "^1.8.1",
+        "debug": "^3.1.0",
+        "fs-readdir-recursive": "^1.1.0",
+        "glob": "^7.1.2",
+        "minimatch": "^3.0.4",
+        "printable": "^0.0.3",
+        "semver": "^6.0.0",
+        "urllib": "^2.25.1"
+      }
+    },
+    "await-event": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/await-event/download/await-event-2.1.0.tgz",
+      "integrity": "sha1-eOn5JoS65AIvn6C18xShFVD5qnY=",
+      "dev": true
+    },
+    "await-first": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/await-first/download/await-first-1.0.0.tgz",
+      "integrity": "sha1-Bq+m23zr5BK+m+VOgt2MbLTNskE=",
+      "dev": true,
+      "requires": {
+        "ee-first": "^1.1.1"
+      }
+    },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.taobao.org/axobject-query/download/axobject-query-2.0.2.tgz",
+      "integrity": "sha1-6hh6vluQArN3+SXYv30cVhrfOPk=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-code-frame/download/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "http://registry.npm.taobao.org/babel-core/download/babel-core-6.26.3.tgz",
+      "integrity": "sha1-suLwnjQtDwyI4vAuBneUEl51wgc=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npm.taobao.org/babel-eslint/download/babel-eslint-7.2.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbabel-eslint%2Fdownload%2Fbabel-eslint-7.2.3.tgz",
+      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "http://registry.npm.taobao.org/babel-generator/download/babel-generator-6.26.1.tgz",
+      "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
+      "dev": true,
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-bindify-decorators/download/babel-helper-bindify-decorators-6.24.1.tgz",
+      "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-builder-binary-assignment-operator-visitor/download/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-builder-react-jsx/download/babel-helper-builder-react-jsx-6.26.0.tgz",
+      "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-call-delegate/download/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-define-map/download/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-explode-assignable-expression/download/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-explode-class/download/babel-helper-explode-class-6.24.1.tgz",
+      "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
+      "dev": true,
+      "requires": {
+        "babel-helper-bindify-decorators": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-function-name/download/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-get-function-arity/download/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-hoist-variables/download/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-optimise-call-expression/download/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-regex/download/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-remap-async-to-generator/download/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helper-replace-supers/download/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-helpers/download/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "http://registry.npm.taobao.org/babel-messages/download/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-check-es2015-constants/download/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-async-functions/download/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-async-generators/download/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-constructor-call": {
+      "version": "6.18.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-class-constructor-call/download/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+      "integrity": "sha1-nLnTn+Q8hgC+yBRkVt3L1OGnZBY=",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-class-properties/download/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
+      "dev": true
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-decorators/download/babel-plugin-syntax-decorators-6.13.0.tgz",
+      "integrity": "sha1-MSVjtNvePMgGzuPkFszurd0RrAs=",
+      "dev": true
+    },
+    "babel-plugin-syntax-do-expressions": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-do-expressions/download/babel-plugin-syntax-do-expressions-6.13.0.tgz",
+      "integrity": "sha1-V0d1YTmqJtOQ0JQQsDdEugfkeW0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-dynamic-import/download/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-exponentiation-operator/download/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-export-extensions": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-export-extensions/download/babel-plugin-syntax-export-extensions-6.13.0.tgz",
+      "integrity": "sha1-cKFITw+QiaToStRLrDU8lbmxJyE=",
+      "dev": true
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.18.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-flow/download/babel-plugin-syntax-flow-6.18.0.tgz",
+      "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0=",
+      "dev": true
+    },
+    "babel-plugin-syntax-function-bind": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-function-bind/download/babel-plugin-syntax-function-bind-6.13.0.tgz",
+      "integrity": "sha1-SMSV8Xe98xqYHnMvVa3AvdJgH0Y=",
+      "dev": true
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-jsx/download/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-object-rest-spread/download/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-syntax-trailing-function-commas/download/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-async-generator-functions/download/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+      "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-generators": "^6.5.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-async-to-generator/download/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-class-constructor-call": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-class-constructor-call/download/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+      "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-class-properties/download/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-decorators/download/babel-plugin-transform-decorators-6.24.1.tgz",
+      "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-class": "^6.24.1",
+        "babel-plugin-syntax-decorators": "^6.13.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-do-expressions": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-do-expressions/download/babel-plugin-transform-do-expressions-6.22.0.tgz",
+      "integrity": "sha1-KMyvkoEtlJws0SgfaQyP3EaK6bs=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-do-expressions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-arrow-functions/download/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-block-scoped-functions/download/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-block-scoping/download/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-classes/download/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-computed-properties/download/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-destructuring/download/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-duplicate-keys/download/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-for-of/download/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-function-name/download/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-literals/download/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-amd/download/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-commonjs/download/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha1-WKeThjqefKhwvcWogRF/+sJ9tvM=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-systemjs/download/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-modules-umd/download/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-object-super/download/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-parameters/download/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-shorthand-properties/download/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-spread/download/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-sticky-regex/download/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-template-literals/download/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-typeof-symbol/download/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-es2015-unicode-regex/download/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-exponentiation-operator/download/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-export-extensions": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-export-extensions/download/babel-plugin-transform-export-extensions-6.22.0.tgz",
+      "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-export-extensions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-flow-strip-types/download/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+      "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-function-bind": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-function-bind/download/babel-plugin-transform-function-bind-6.22.0.tgz",
+      "integrity": "sha1-xvuOlqwpajELjPjqQBRiQH3fapc=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-function-bind": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-object-rest-spread/download/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.25.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-react-display-name/download/babel-plugin-transform-react-display-name-6.25.0.tgz",
+      "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-react-jsx/download/babel-plugin-transform-react-jsx-6.24.1.tgz",
+      "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-self": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-react-jsx-self/download/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+      "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.22.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-react-jsx-source/download/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+      "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-regenerator/download/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.10.0"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-plugin-transform-strict-mode/download/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-env/download/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha1-3qefpOvriDzTXasH4mDBycBN93o=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-flow/download/babel-preset-flow-6.23.0.tgz",
+      "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
+      }
+    },
+    "babel-preset-react": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-react/download/babel-preset-react-6.24.1.tgz",
+      "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
+      }
+    },
+    "babel-preset-stage-0": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-stage-0/download/babel-preset-stage-0-6.24.1.tgz",
+      "integrity": "sha1-VkLRUEL5E4TX5a+LyIsduVsDnmo=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-do-expressions": "^6.22.0",
+        "babel-plugin-transform-function-bind": "^6.22.0",
+        "babel-preset-stage-1": "^6.24.1"
+      }
+    },
+    "babel-preset-stage-1": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-stage-1/download/babel-preset-stage-1-6.24.1.tgz",
+      "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-class-constructor-call": "^6.24.1",
+        "babel-plugin-transform-export-extensions": "^6.22.0",
+        "babel-preset-stage-2": "^6.24.1"
+      }
+    },
+    "babel-preset-stage-2": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-stage-2/download/babel-preset-stage-2-6.24.1.tgz",
+      "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-plugin-transform-class-properties": "^6.24.1",
+        "babel-plugin-transform-decorators": "^6.24.1",
+        "babel-preset-stage-3": "^6.24.1"
+      }
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "resolved": "http://registry.npm.taobao.org/babel-preset-stage-3/download/babel-preset-stage-3-6.24.1.tgz",
+      "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-generator-functions": "^6.24.1",
+        "babel-plugin-transform-async-to-generator": "^6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+        "babel-plugin-transform-object-rest-spread": "^6.22.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-register/download/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-runtime/download/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-template/download/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-traverse/download/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "http://registry.npm.taobao.org/babel-types/download/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "http://registry.npm.taobao.org/babylon/download/babylon-6.18.0.tgz",
+      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/balanced-match/download/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "http://registry.npm.taobao.org/base/download/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npm.taobao.org/base64-js/download/base64-js-1.3.1.tgz",
+      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "http://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.13.1.tgz",
+      "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+      "dev": true
+    },
+    "black-hole-stream": {
+      "version": "0.0.1",
+      "resolved": "http://registry.npm.taobao.org/black-hole-stream/download/black-hole-stream-0.0.1.tgz",
+      "integrity": "sha1-M7ega58edFPWBBuCl0SB0hUq6kI=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "http://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "http://registry.npm.taobao.org/braces/download/braces-2.3.2.tgz",
+      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "http://registry.npm.taobao.org/browser-stdout/download/browser-stdout-1.3.1.tgz",
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+      "dev": true
+    },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npm.taobao.org/browserslist/download/browserslist-3.2.8.tgz",
+      "integrity": "sha1-sABTYdZHHw9ZUnl6dvyYXx+Xj8Y=",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
+      }
+    },
+    "buffer": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npm.taobao.org/buffer/download/buffer-5.3.0.tgz",
+      "integrity": "sha1-X5+l/v45OYiND9v32WTiqFMf1pw=",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "http://registry.npm.taobao.org/busboy/download/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "dev": true,
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-1.1.14.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
+    "byte": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/byte/download/byte-2.0.0.tgz",
+      "integrity": "sha1-xhiM9+S+ktqsIvRzEvWh9kCRsYo=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "long": "^4.0.0",
+        "utility": "^1.13.1"
+      }
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/bytes/download/bytes-3.1.0.tgz",
+      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/cache-base/download/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/cache-content-type/download/cache-content-type-1.0.1.tgz",
+      "integrity": "sha1-A1zeKwjuISn0qDFeqPAKANuhRTw=",
+      "dev": true,
+      "requires": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      }
+    },
+    "cache-require-paths": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.taobao.org/cache-require-paths/download/cache-require-paths-0.3.0.tgz",
+      "integrity": "sha1-EqYHWj5JiNpMIvIY4pSFZj5MSmM=",
+      "dev": true
+    },
+    "call-matcher": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/call-matcher/download/call-matcher-1.1.0.tgz",
+      "integrity": "sha1-I7LBvHqDlMi+KGCdd929V4ZoBDI=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "deep-equal": "^1.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.0.0"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/call-me-maybe/download/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "call-signature": {
+      "version": "0.0.2",
+      "resolved": "http://registry.npm.taobao.org/call-signature/download/call-signature-0.0.2.tgz",
+      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
+      "dev": true
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.taobao.org/caller-path/download/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npm.taobao.org/callsites/download/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/camel-case/download/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000989",
+      "resolved": "https://registry.npm.taobao.org/caniuse-lite/download/caniuse-lite-1.0.30000989.tgz",
+      "integrity": "sha1-uRk+KTzPfkQmxSRRNLjypWwKxLk=",
+      "dev": true
+    },
+    "cfork": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npm.taobao.org/cfork/download/cfork-1.8.0.tgz",
+      "integrity": "sha1-0P3i3rq71uB1j/M/IcL5gMzAVxE=",
+      "dev": true,
+      "requires": {
+        "utility": "^1.12.0"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "chan": {
+      "version": "0.6.1",
+      "resolved": "http://registry.npm.taobao.org/chan/download/chan-0.6.1.tgz",
+      "integrity": "sha1-7ArRMuW8YsJ+8QzL/E2NzYygBkA=",
+      "dev": true
+    },
+    "change-case": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/change-case/download/change-case-3.1.0.tgz",
+      "integrity": "sha1-DmEbftyZUt8uhROye0LecmR90X4=",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npm.taobao.org/chardet/download/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npm.taobao.org/chokidar/download/chokidar-2.1.6.tgz?cache=0&sync_timestamp=1562457945399&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchokidar%2Fdownload%2Fchokidar-2.1.6.tgz",
+      "integrity": "sha1-tsrWU6kp4kTOioNCRBZNJB+pVMU=",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "http://registry.npm.taobao.org/circular-json/download/circular-json-0.3.3.tgz",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "dev": true
+    },
+    "circular-json-for-egg": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/circular-json-for-egg/download/circular-json-for-egg-1.0.0.tgz",
+      "integrity": "sha1-6stxtXryi0giyrxSpZYc0vCBf8U=",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "http://registry.npm.taobao.org/class-utils/download/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/cli-cursor/download/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/cli-width/download/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "http://registry.npm.taobao.org/cliui/download/cliui-4.1.0.tgz",
+      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "cluster-client": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npm.taobao.org/cluster-client/download/cluster-client-3.0.1.tgz",
+      "integrity": "sha1-c5y1KaCXQu1EixKBoO9RasJFnGE=",
+      "dev": true,
+      "requires": {
+        "byte": "^2.0.0",
+        "co": "^4.6.0",
+        "debug": "^4.1.1",
+        "egg-logger": "^2.3.2",
+        "is-type-of": "^1.2.1",
+        "json-stringify-safe": "^5.0.1",
+        "long": "^4.0.0",
+        "mz-modules": "^2.1.0",
+        "sdk-base": "^3.5.1",
+        "serialize-json": "^1.0.3",
+        "tcp-base": "^3.1.0",
+        "utility": "^1.15.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "cluster-reload": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/cluster-reload/download/cluster-reload-1.0.2.tgz",
+      "integrity": "sha1-NGv1hJ0Y5FkLzBsw7kcNTKvxXBA=",
+      "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "http://registry.npm.taobao.org/co/download/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "co-body": {
+      "version": "6.0.0",
+      "resolved": "http://registry.npm.taobao.org/co-body/download/co-body-6.0.0.tgz",
+      "integrity": "sha1-lluTN9f1ZVSAeHRx9CN2ZIIIJ+M=",
+      "dev": true,
+      "requires": {
+        "inflation": "^2.0.0",
+        "qs": "^6.5.2",
+        "raw-body": "^2.3.3",
+        "type-is": "^1.6.16"
+      }
+    },
+    "co-busboy": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npm.taobao.org/co-busboy/download/co-busboy-1.4.0.tgz",
+      "integrity": "sha1-rJuFxKlm8Dt99V1TdGoNyck/p0E=",
+      "dev": true,
+      "requires": {
+        "black-hole-stream": "~0.0.1",
+        "busboy": "^0.2.8",
+        "chan": "^0.6.1"
+      }
+    },
+    "co-mocha": {
+      "version": "1.2.2",
+      "resolved": "http://registry.npm.taobao.org/co-mocha/download/co-mocha-1.2.2.tgz",
+      "integrity": "sha1-xP3yTTf0PKTaZosUVCqW6Td0eas=",
+      "dev": true,
+      "requires": {
+        "co": "^4.0.0",
+        "is-generator": "^1.0.1"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/code-point-at/download/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "coffee": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npm.taobao.org/coffee/download/coffee-5.2.2.tgz",
+      "integrity": "sha1-ttkfunCtW7LHkTV05e5e1ZJXJG4=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.1.0",
+        "is-type-of": "^1.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/collection-visit/download/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "http://registry.npm.taobao.org/color-convert/download/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/color-name/download/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "http://registry.npm.taobao.org/colors/download/colors-1.3.3.tgz",
+      "integrity": "sha1-OeAF1Uav4B4B+cTKj6UPaGoBIF0=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npm.taobao.org/combined-stream/download/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.20.0.tgz?cache=0&sync_timestamp=1565398176321&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.20.0.tgz",
+      "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
+      "dev": true
+    },
+    "common-bin": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npm.taobao.org/common-bin/download/common-bin-2.8.2.tgz",
+      "integrity": "sha1-HisiEbYFjq02M1+Xl6A0hAN8q3o=",
+      "dev": true,
+      "requires": {
+        "@types/dargs": "^5.1.0",
+        "@types/node": "^10.12.18",
+        "@types/yargs": "^12.0.4",
+        "chalk": "^2.4.1",
+        "change-case": "^3.0.2",
+        "co": "^4.6.0",
+        "dargs": "^6.0.0",
+        "debug": "^4.1.0",
+        "is-type-of": "^1.2.1",
+        "semver": "^5.5.1",
+        "yargs": "^12.0.2",
+        "yargs-parser": "^11.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.15",
+          "resolved": "https://registry.npm.taobao.org/@types/node/download/@types/node-10.14.15.tgz?cache=0&sync_timestamp=1565214337285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fnode%2Fdownload%2F%40types%2Fnode-10.14.15.tgz",
+          "integrity": "sha1-6Pdym2Mb4bAq4TD/C2Hz4BgABkA=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/component-emitter/download/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
+      "dev": true
+    },
+    "compressible": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npm.taobao.org/compressible/download/compressible-2.0.17.tgz",
+      "integrity": "sha1-bowQihatWDhKl386SCyiC/8vOME=",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.40.0 < 2"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://registry.npm.taobao.org/concat-map/download/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "http://registry.npm.taobao.org/concat-stream/download/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz?cache=0&sync_timestamp=1562592096220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisarray%2Fdownload%2Fisarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-2.3.6.tgz",
+          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/constant-case/download/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "dev": true,
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.taobao.org/contains-path/download/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "http://registry.npm.taobao.org/content-disposition/download/content-disposition-0.5.3.tgz",
+      "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/content-type/download/content-type-1.0.4.tgz",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.taobao.org/convert-source-map/download/convert-source-map-1.6.0.tgz",
+      "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npm.taobao.org/cookie/download/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/cookiejar/download/cookiejar-2.1.2.tgz",
+      "integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw=",
+      "dev": true
+    },
+    "cookies": {
+      "version": "0.7.3",
+      "resolved": "http://registry.npm.taobao.org/cookies/download/cookies-0.7.3.tgz",
+      "integrity": "sha1-eRLOIfvy6MLacM8cPzUa7PWdrfo=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "keygrip": "~1.0.3"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/copy-descriptor/download/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/copy-to/download/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npm.taobao.org/core-js/download/core-js-2.6.9.tgz",
+      "integrity": "sha1-a0shRiDINBUuF5Mjcn/Bl0GwhPI=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/core-util-is/download/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "http://registry.npm.taobao.org/crc/download/crc-3.8.0.tgz",
+      "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "crequire": {
+      "version": "1.8.1",
+      "resolved": "http://registry.npm.taobao.org/crequire/download/crequire-1.8.1.tgz",
+      "integrity": "sha1-rIHyBHhrXyARlOsWmM9EGxCktX0=",
+      "dev": true
+    },
+    "cron-parser": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npm.taobao.org/cron-parser/download/cron-parser-2.13.0.tgz",
+      "integrity": "sha1-b5MLtvKTF5DSqe7IOz7CduJ6ZyU=",
+      "dev": true,
+      "requires": {
+        "is-nan": "^1.2.1",
+        "moment-timezone": "^0.5.25"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "http://registry.npm.taobao.org/cross-spawn/download/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "csrf": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/csrf/download/csrf-3.1.0.tgz",
+      "integrity": "sha1-7HXpZW0ATWdLjvW6R7Qfv9bLnDA=",
+      "dev": true,
+      "requires": {
+        "rndm": "1.2.0",
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
+      }
+    },
+    "cssfilter": {
+      "version": "0.0.10",
+      "resolved": "http://registry.npm.taobao.org/cssfilter/download/cssfilter-0.0.10.tgz",
+      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=",
+      "dev": true
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/d/download/d-1.0.1.tgz",
+      "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "damerau-levenshtein": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npm.taobao.org/damerau-levenshtein/download/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha1-eAz3FE6y6NvRw7uDrjEQDMwxpBQ=",
+      "dev": true
+    },
+    "dargs": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npm.taobao.org/dargs/download/dargs-6.1.0.tgz",
+      "integrity": "sha1-HzubVjk+z4yqfL/WwxSW/8+5snI=",
+      "dev": true
+    },
+    "data-uri-to-buffer": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/data-uri-to-buffer/download/data-uri-to-buffer-2.0.1.tgz",
+      "integrity": "sha1-yo9W/jix/TKUc+nRtKmvzYzhwEU=",
+      "dev": true,
+      "requires": {
+        "@types/node": "^8.0.7"
+      }
+    },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/debounce/download/debounce-1.2.0.tgz",
+      "integrity": "sha1-RKVAq8DqmUMBjcDqqVzOh/Zc0TE=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
+      "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/decamelize/download/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npm.taobao.org/decode-uri-component/download/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/deep-equal/download/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "http://registry.npm.taobao.org/deep-is/download/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "default-user-agent": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/default-user-agent/download/default-user-agent-1.0.0.tgz",
+      "integrity": "sha1-FsRu/cq6PtxF8k8r1IaLAbfCrcY=",
+      "dev": true,
+      "requires": {
+        "os-name": "~1.0.3"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/define-properties/download/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "degenerator": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/degenerator/download/degenerator-1.0.4.tgz",
+      "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
+      "dev": true,
+      "requires": {
+        "ast-types": "0.x.x",
+        "escodegen": "1.x.x",
+        "esprima": "3.x.x"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/delayed-stream/download/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/delegates/download/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/depd/download/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/destroy/download/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npm.taobao.org/detect-indent/download/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "detect-port": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/detect-port/download/detect-port-1.3.0.tgz",
+      "integrity": "sha1-2cQOmsyt1N9crGp4Ku/QFNVz0fE=",
+      "dev": true,
+      "requires": {
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "http://registry.npm.taobao.org/dicer/download/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-1.1.14.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "http://registry.npm.taobao.org/diff/download/diff-3.5.0.tgz",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+      "dev": true
+    },
+    "diff-match-patch": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/diff-match-patch/download/diff-match-patch-1.0.4.tgz",
+      "integrity": "sha1-asS1UjdGN2HE2vDcYD64aRJHRLE=",
+      "dev": true
+    },
+    "digest-header": {
+      "version": "0.0.1",
+      "resolved": "http://registry.npm.taobao.org/digest-header/download/digest-header-0.0.1.tgz",
+      "integrity": "sha1-Ecz23uxXZqw3l0TZAcEsuklRS+Y=",
+      "dev": true,
+      "requires": {
+        "utility": "0.1.11"
+      },
+      "dependencies": {
+        "utility": {
+          "version": "0.1.11",
+          "resolved": "http://registry.npm.taobao.org/utility/download/utility-0.1.11.tgz",
+          "integrity": "sha1-/eYM+bTkdRlHoM9dEEzik2ciZxU=",
+          "dev": true,
+          "requires": {
+            "address": ">=0.0.1"
+          }
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/dir-glob/download/dir-glob-2.0.0.tgz",
+      "integrity": "sha1-CyBdK2rvmCOMooZZioIE0p0KADQ=",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "path-type": "^3.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/doctrine/download/doctrine-2.1.0.tgz",
+      "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "dot-case": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/dot-case/download/dot-case-2.1.1.tgz",
+      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "dot-prop": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npm.taobao.org/dot-prop/download/dot-prop-4.2.0.tgz",
+      "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+      "dev": true,
+      "requires": {
+        "is-obj": "^1.0.0"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/duplexer/download/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npm.taobao.org/eastasianwidth/download/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
+      "dev": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/ee-first/download/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "egg": {
+      "version": "2.20.2",
+      "resolved": "https://registry.npm.taobao.org/egg/download/egg-2.20.2.tgz",
+      "integrity": "sha1-GlMqWFCCC9a4ZLF9cQgof5ZWkG8=",
+      "dev": true,
+      "requires": {
+        "@types/accepts": "^1.3.5",
+        "@types/koa": "^2.0.48",
+        "@types/koa-router": "^7.0.40",
+        "@types/urllib": "^2.28.1",
+        "accepts": "^1.3.5",
+        "agentkeepalive": "^4.0.2",
+        "cache-content-type": "^1.0.1",
+        "circular-json-for-egg": "^1.0.0",
+        "cluster-client": "^3.0.1",
+        "debug": "^4.1.1",
+        "delegates": "^1.0.0",
+        "egg-cluster": "^1.23.0",
+        "egg-cookies": "^2.2.6",
+        "egg-core": "^4.16.1",
+        "egg-development": "^2.4.2",
+        "egg-i18n": "^2.0.0",
+        "egg-jsonp": "^2.0.0",
+        "egg-logger": "^2.3.2",
+        "egg-logrotator": "^3.0.5",
+        "egg-multipart": "^2.4.0",
+        "egg-onerror": "^2.1.0",
+        "egg-schedule": "^3.6.0",
+        "egg-security": "^2.4.3",
+        "egg-session": "^3.1.0",
+        "egg-static": "^2.2.0",
+        "egg-view": "^2.1.2",
+        "egg-watcher": "^3.1.0",
+        "extend2": "^1.0.0",
+        "graceful": "^1.0.2",
+        "humanize-ms": "^1.2.1",
+        "is-type-of": "^1.2.1",
+        "koa-bodyparser": "^4.2.1",
+        "koa-is-json": "^1.0.0",
+        "koa-override": "^3.0.0",
+        "ms": "^2.1.1",
+        "mz": "^2.7.0",
+        "on-finished": "^2.3.0",
+        "sendmessage": "^1.1.0",
+        "urllib": "^2.33.0",
+        "utility": "^1.15.0",
+        "ylru": "^1.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "egg-bin": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npm.taobao.org/egg-bin/download/egg-bin-4.13.0.tgz",
+      "integrity": "sha1-15pzDrdvi4Rs2hTJfexT4GmE4ao=",
+      "dev": true,
+      "requires": {
+        "autod": "^3.1.0",
+        "chalk": "^2.4.2",
+        "co-mocha": "^1.2.2",
+        "common-bin": "^2.8.1",
+        "debug": "^4.1.1",
+        "detect-port": "^1.3.0",
+        "egg-ts-helper": "^1.25.2",
+        "egg-utils": "^2.4.1",
+        "espower-typescript": "9.0.1",
+        "globby": "^9.2.0",
+        "inspector-proxy": "^1.2.1",
+        "intelli-espower-loader": "^1.0.1",
+        "jest-changed-files": "^24.7.0",
+        "mocha": "^6.0.2",
+        "mz-modules": "^2.1.0",
+        "nyc": "^13.3.0",
+        "power-assert": "^1.6.1",
+        "semver": "^6.0.0",
+        "test-exclude": "^5.1.0",
+        "ts-node": "^7",
+        "ypkgfiles": "^1.6.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npm.taobao.org/ansi-colors/download/ansi-colors-3.2.3.tgz",
+          "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "egg-ts-helper": {
+          "version": "1.25.5",
+          "resolved": "https://registry.npm.taobao.org/egg-ts-helper/download/egg-ts-helper-1.25.5.tgz",
+          "integrity": "sha1-BLPy5BBcqlpk2hIDzFgg0dJu9xk=",
+          "dev": true,
+          "requires": {
+            "cache-require-paths": "^0.3.0",
+            "chalk": "^2.4.2",
+            "chokidar": "^2.0.1",
+            "commander": "^2.15.1",
+            "debug": "^3.1.0",
+            "dot-prop": "^4.2.0",
+            "enquirer": "^2.3.0",
+            "globby": "^8.0.1",
+            "mkdirp": "^0.5.1",
+            "ts-node": "^7.0.0",
+            "tslib": "^1.9.3",
+            "typescript": "^3.0.0",
+            "yn": "^3.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
+              "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "globby": {
+              "version": "8.0.2",
+              "resolved": "https://registry.npm.taobao.org/globby/download/globby-8.0.2.tgz?cache=0&sync_timestamp=1562335642755&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobby%2Fdownload%2Fglobby-8.0.2.tgz",
+              "integrity": "sha1-VpdhnM2VxSdduy1vqkIIfBqUHY0=",
+              "dev": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "dir-glob": "2.0.0",
+                "fast-glob": "^2.0.2",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
+              }
+            }
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "http://registry.npm.taobao.org/get-caller-file/download/get-caller-file-2.0.5.tgz",
+          "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+          "dev": true
+        },
+        "globby": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npm.taobao.org/globby/download/globby-9.2.0.tgz?cache=0&sync_timestamp=1562335642755&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobby%2Fdownload%2Fglobby-9.2.0.tgz",
+          "integrity": "sha1-/QKacGxwPSm90XD0tts6P3p8tj0=",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^1.0.2",
+            "dir-glob": "^2.2.2",
+            "fast-glob": "^2.2.6",
+            "glob": "^7.1.3",
+            "ignore": "^4.0.3",
+            "pify": "^4.0.1",
+            "slash": "^2.0.0"
+          },
+          "dependencies": {
+            "dir-glob": {
+              "version": "2.2.2",
+              "resolved": "https://registry.npm.taobao.org/dir-glob/download/dir-glob-2.2.2.tgz",
+              "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
+              "dev": true,
+              "requires": {
+                "path-type": "^3.0.0"
+              }
+            },
+            "ignore": {
+              "version": "4.0.6",
+              "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-4.0.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fignore%2Fdownload%2Fignore-4.0.6.tgz",
+              "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+              "dev": true
+            },
+            "pify": {
+              "version": "4.0.1",
+              "resolved": "http://registry.npm.taobao.org/pify/download/pify-4.0.1.tgz",
+              "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+              "dev": true
+            },
+            "slash": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npm.taobao.org/slash/download/slash-2.0.0.tgz",
+              "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+              "dev": true
+            }
+          }
+        },
+        "mocha": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npm.taobao.org/mocha/download/mocha-6.2.0.tgz",
+          "integrity": "sha1-+Ja2QoQ0RdG7i8pg6r2SBriRblY=",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "3.2.3",
+            "browser-stdout": "1.3.1",
+            "debug": "3.2.6",
+            "diff": "3.5.0",
+            "escape-string-regexp": "1.0.5",
+            "find-up": "3.0.0",
+            "glob": "7.1.3",
+            "growl": "1.10.5",
+            "he": "1.2.0",
+            "js-yaml": "3.13.1",
+            "log-symbols": "2.2.0",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "ms": "2.1.1",
+            "node-environment-flags": "1.0.5",
+            "object.assign": "4.1.0",
+            "strip-json-comments": "2.0.1",
+            "supports-color": "6.0.0",
+            "which": "1.3.1",
+            "wide-align": "1.1.3",
+            "yargs": "13.2.2",
+            "yargs-parser": "13.0.0",
+            "yargs-unparser": "1.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.2.6.tgz",
+              "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+              "dev": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npm.taobao.org/glob/download/glob-7.1.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglob%2Fdownload%2Fglob-7.1.3.tgz",
+              "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+              "dev": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.1.tgz",
+              "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.0.0.tgz",
+              "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/require-main-filename/download/require-main-filename-2.0.0.tgz",
+          "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.2.2",
+          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-13.2.2.tgz",
+          "integrity": "sha1-DBAfWArpXOp/Odkn53cOP9yX+ZM=",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-13.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-13.0.0.tgz",
+          "integrity": "sha1-P8RPPnaovbHMNgLoYBCGAuXM3os=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "egg-ci": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npm.taobao.org/egg-ci/download/egg-ci-1.13.0.tgz?cache=0&sync_timestamp=1563861605360&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fegg-ci%2Fdownload%2Fegg-ci-1.13.0.tgz",
+      "integrity": "sha1-gVznH3ZX+pkf+XbKcnkOH7YGicg=",
+      "dev": true,
+      "requires": {
+        "nunjucks": "^3.1.3"
+      }
+    },
+    "egg-cluster": {
+      "version": "1.25.0",
+      "resolved": "https://registry.npm.taobao.org/egg-cluster/download/egg-cluster-1.25.0.tgz?cache=0&sync_timestamp=1563949073332&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fegg-cluster%2Fdownload%2Fegg-cluster-1.25.0.tgz",
+      "integrity": "sha1-ClE0GpUDhgtK1yhXPFLF+fNJXhs=",
+      "dev": true,
+      "requires": {
+        "await-event": "^2.1.0",
+        "cfork": "^1.7.1",
+        "cluster-reload": "^1.0.2",
+        "co": "^4.6.0",
+        "debug": "^4.1.1",
+        "depd": "^2.0.0",
+        "detect-port": "^1.3.0",
+        "egg-logger": "^2.3.2",
+        "egg-utils": "^2.4.1",
+        "get-ready": "^2.0.1",
+        "graceful-process": "^1.2.0",
+        "is-type-of": "^1.2.1",
+        "mz-modules": "^2.1.0",
+        "ps-tree": "^1.2.0",
+        "semver": "^5.6.0",
+        "sendmessage": "^1.1.0",
+        "utility": "^1.15.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/depd/download/depd-2.0.0.tgz",
+          "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "egg-cookies": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npm.taobao.org/egg-cookies/download/egg-cookies-2.2.7.tgz",
+      "integrity": "sha1-QvKfSEH8W8Ib1R+RNQgaTfNxNxw=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "scmp": "^2.0.0",
+        "utility": "^1.14.0"
+      }
+    },
+    "egg-core": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npm.taobao.org/egg-core/download/egg-core-4.17.3.tgz",
+      "integrity": "sha1-/jBii9WOUYGOVGRlx/OmEvNwGc4=",
+      "dev": true,
+      "requires": {
+        "@eggjs/router": "^2.0.0",
+        "@types/depd": "^1.1.32",
+        "@types/koa": "^2.0.48",
+        "co": "^4.6.0",
+        "debug": "^4.1.1",
+        "depd": "^2.0.0",
+        "egg-logger": "^2.4.1",
+        "egg-path-matching": "^1.0.1",
+        "extend2": "^1.0.0",
+        "get-ready": "^2.0.1",
+        "globby": "^8.0.2",
+        "is-type-of": "^1.2.1",
+        "koa": "^2.7.0",
+        "koa-convert": "^1.2.0",
+        "node-homedir": "^1.1.1",
+        "ready-callback": "^2.1.0",
+        "utility": "^1.16.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/depd/download/depd-2.0.0.tgz",
+          "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "egg-development": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npm.taobao.org/egg-development/download/egg-development-2.4.3.tgz",
+      "integrity": "sha1-phseHv4HudWe1Ee+oYSJWZT7kfE=",
+      "dev": true,
+      "requires": {
+        "debounce": "^1.1.0",
+        "multimatch": "^2.1.0",
+        "mz": "^2.7.0",
+        "mz-modules": "^2.1.0",
+        "utility": "^1.13.1"
+      }
+    },
+    "egg-i18n": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npm.taobao.org/egg-i18n/download/egg-i18n-2.1.1.tgz",
+      "integrity": "sha1-Phpjjtu2pENyKbFjuLNxXSQ3bw0=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "koa-locales": "^1.11.0"
+      }
+    },
+    "egg-jsonp": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/egg-jsonp/download/egg-jsonp-2.0.0.tgz",
+      "integrity": "sha1-0BRfqki1QiaBiDQwQh58JFiXGR8=",
+      "dev": true,
+      "requires": {
+        "is-type-of": "^1.2.0",
+        "jsonp-body": "^1.0.0"
+      }
+    },
+    "egg-logger": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npm.taobao.org/egg-logger/download/egg-logger-2.4.1.tgz",
+      "integrity": "sha1-WP0ye8YNl+OEKXNguAm0D01EfVU=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "circular-json-for-egg": "^1.0.0",
+        "debug": "^2.6.9",
+        "depd": "^2.0.0",
+        "iconv-lite": "^0.4.24",
+        "mkdirp": "^0.5.1",
+        "utility": "^1.15.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/depd/download/depd-2.0.0.tgz",
+          "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "egg-logrotator": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npm.taobao.org/egg-logrotator/download/egg-logrotator-3.1.0.tgz",
+      "integrity": "sha1-ZAuK1RocWW3jroJYrqFgHDRLR8U=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "moment": "^2.24.0",
+        "mz": "^2.7.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "egg-mock": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npm.taobao.org/egg-mock/download/egg-mock-3.23.1.tgz",
+      "integrity": "sha1-DXUoxoAG1SWfaps00SSL4fmgaQk=",
+      "dev": true,
+      "requires": {
+        "@types/power-assert": "^1.5.0",
+        "await-event": "^2.1.0",
+        "co": "^4.6.0",
+        "coffee": "^5.2.1",
+        "debug": "^4.1.1",
+        "detect-port": "^1.3.0",
+        "egg-logger": "^2.4.1",
+        "egg-utils": "^2.4.1",
+        "extend2": "^1.0.0",
+        "get-ready": "^2.0.1",
+        "globby": "^9.2.0",
+        "is-type-of": "^1.2.1",
+        "ko-sleep": "^1.0.3",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mm": "^2.5.0",
+        "mz-modules": "^2.1.0",
+        "power-assert": "^1.6.1",
+        "supertest": "^4.0.2",
+        "urllib": "^2.33.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "dir-glob": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npm.taobao.org/dir-glob/download/dir-glob-2.2.2.tgz",
+          "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
+          "dev": true,
+          "requires": {
+            "path-type": "^3.0.0"
+          }
+        },
+        "globby": {
+          "version": "9.2.0",
+          "resolved": "https://registry.npm.taobao.org/globby/download/globby-9.2.0.tgz?cache=0&sync_timestamp=1562335642755&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobby%2Fdownload%2Fglobby-9.2.0.tgz",
+          "integrity": "sha1-/QKacGxwPSm90XD0tts6P3p8tj0=",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^1.0.2",
+            "dir-glob": "^2.2.2",
+            "fast-glob": "^2.2.6",
+            "glob": "^7.1.3",
+            "ignore": "^4.0.3",
+            "pify": "^4.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "ignore": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-4.0.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fignore%2Fdownload%2Fignore-4.0.6.tgz",
+          "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "http://registry.npm.taobao.org/pify/download/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/slash/download/slash-2.0.0.tgz",
+          "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+          "dev": true
+        }
+      }
+    },
+    "egg-multipart": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npm.taobao.org/egg-multipart/download/egg-multipart-2.9.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fegg-multipart%2Fdownload%2Fegg-multipart-2.9.0.tgz",
+      "integrity": "sha1-LzN0V4bZdW8nuWGQmToRhYAZFaY=",
+      "dev": true,
+      "requires": {
+        "co-busboy": "^1.4.0",
+        "egg-path-matching": "^1.0.1",
+        "humanize-bytes": "^1.0.1",
+        "moment": "^2.22.2",
+        "mz": "^2.7.0",
+        "mz-modules": "^2.1.0",
+        "stream-wormhole": "^1.1.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "egg-onerror": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/egg-onerror/download/egg-onerror-2.1.0.tgz",
+      "integrity": "sha1-4F3AjjmuwWUYtkBTuLyHQRCrqfc=",
+      "dev": true,
+      "requires": {
+        "cookie": "^0.3.1",
+        "koa-onerror": "^4.0.0",
+        "mustache": "^2.3.0",
+        "stack-trace": "^0.0.10"
+      }
+    },
+    "egg-path-matching": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/egg-path-matching/download/egg-path-matching-1.0.1.tgz",
+      "integrity": "sha1-zPxOQIrNHPlKf2cvuMlp5FaIORM=",
+      "dev": true,
+      "requires": {
+        "path-to-regexp": "^1.7.0"
+      }
+    },
+    "egg-schedule": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npm.taobao.org/egg-schedule/download/egg-schedule-3.6.4.tgz",
+      "integrity": "sha1-CpLse67H2q/lGR6K4OMShX+yYAk=",
+      "dev": true,
+      "requires": {
+        "cron-parser": "^2.4.4",
+        "humanize-ms": "^1.2.1",
+        "is-type-of": "^1.2.0",
+        "safe-timers": "^1.1.0",
+        "utility": "^1.13.1"
+      }
+    },
+    "egg-security": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npm.taobao.org/egg-security/download/egg-security-2.6.1.tgz?cache=0&sync_timestamp=1565338927661&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fegg-security%2Fdownload%2Fegg-security-2.6.1.tgz",
+      "integrity": "sha1-yXqcBxZrZPtTel3lLrLZiim0Eoo=",
+      "dev": true,
+      "requires": {
+        "csrf": "^3.0.6",
+        "debug": "^4.1.1",
+        "delegates": "^1.0.0",
+        "egg-path-matching": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "extend": "^3.0.1",
+        "ip": "^1.1.5",
+        "koa-compose": "^4.0.0",
+        "matcher": "^1.1.1",
+        "methods": "^1.1.2",
+        "nanoid": "^2.0.1",
+        "platform": "^1.3.4",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.15",
+        "xss": "^1.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "koa-compose": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npm.taobao.org/koa-compose/download/koa-compose-4.1.0.tgz",
+          "integrity": "sha1-UHMGuTcZAdtBEhyBLpI9DWfT6Hc=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "egg-session": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/egg-session/download/egg-session-3.1.0.tgz",
+      "integrity": "sha1-WzuvD2By+lW10Tvi5su6F+JVO/4=",
+      "dev": true,
+      "requires": {
+        "koa-session": "^5.7.0"
+      }
+    },
+    "egg-static": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/egg-static/download/egg-static-2.2.0.tgz",
+      "integrity": "sha1-zHBylWNxkdCabH4HDL6y9lEMakc=",
+      "dev": true,
+      "requires": {
+        "is-type-of": "^1.2.1",
+        "koa-compose": "^4.1.0",
+        "koa-range": "^0.3.0",
+        "koa-static-cache": "^5.1.2",
+        "mkdirp": "^0.5.1",
+        "ylru": "^1.2.1"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npm.taobao.org/koa-compose/download/koa-compose-4.1.0.tgz",
+          "integrity": "sha1-UHMGuTcZAdtBEhyBLpI9DWfT6Hc=",
+          "dev": true
+        }
+      }
+    },
+    "egg-utils": {
+      "version": "2.4.1",
+      "resolved": "http://registry.npm.taobao.org/egg-utils/download/egg-utils-2.4.1.tgz",
+      "integrity": "sha1-vHozAxWhALxFg4pU90T91dR8Myo=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1",
+        "utility": "^1.13.1"
+      }
+    },
+    "egg-view": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/egg-view/download/egg-view-2.1.2.tgz",
+      "integrity": "sha1-FEaYsj0bGH4XZOXtzq4YGYENeh8=",
+      "dev": true,
+      "requires": {
+        "mz": "^2.7.0"
+      }
+    },
+    "egg-watcher": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/egg-watcher/download/egg-watcher-3.1.0.tgz",
+      "integrity": "sha1-m8TsMI7pQRBUbgWbvyLaW9Px6qA=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "sdk-base": "^3.5.0",
+        "wt": "^1.2.0"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.225",
+      "resolved": "https://registry.npm.taobao.org/electron-to-chromium/download/electron-to-chromium-1.3.225.tgz",
+      "integrity": "sha1-xnhkdbXrX0ka3gGni4K6LFv99ys=",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "http://registry.npm.taobao.org/emoji-regex/download/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "dev": true
+    },
+    "empower": {
+      "version": "1.3.1",
+      "resolved": "http://registry.npm.taobao.org/empower/download/empower-1.3.1.tgz",
+      "integrity": "sha1-dol5y7s21x2PXtqrZj3qy52rkWw=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "empower-core": "^1.2.0"
+      }
+    },
+    "empower-assert": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/empower-assert/download/empower-assert-1.1.0.tgz",
+      "integrity": "sha1-jTJ/vmmoivkN2pjRv8mCnSok/WI=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.2.0"
+      }
+    },
+    "empower-core": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/empower-core/download/empower-core-1.2.0.tgz",
+      "integrity": "sha1-zj+ySE1Rh/opwj+6g0Swsv31YBw=",
+      "dev": true,
+      "requires": {
+        "call-signature": "0.0.2",
+        "core-js": "^2.0.0"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "http://registry.npm.taobao.org/end-of-stream/download/end-of-stream-1.4.1.tgz",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npm.taobao.org/enquirer/download/enquirer-2.3.1.tgz",
+      "integrity": "sha1-8b9S6jhHBSX0FBLXI6YrpoaFWcY=",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.2.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "http://registry.npm.taobao.org/error-ex/download/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-inject": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/error-inject/download/error-inject-1.0.0.tgz",
+      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=",
+      "dev": true
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "http://registry.npm.taobao.org/es-abstract/download/es-abstract-1.13.0.tgz",
+      "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/es-to-primitive/download/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npm.taobao.org/es5-ext/download/es5-ext-0.10.50.tgz",
+      "integrity": "sha1-bQ4joKvbJwGOWsT9CbQSvFUXp3g=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/es6-iterator/download/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "http://registry.npm.taobao.org/es6-map/download/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npm.taobao.org/es6-promise/download/es6-promise-4.2.8.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fes6-promise%2Fdownload%2Fes6-promise-4.2.8.tgz",
+      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "http://registry.npm.taobao.org/es6-promisify/download/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "http://registry.npm.taobao.org/es6-set/download/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "http://registry.npm.taobao.org/es6-symbol/download/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npm.taobao.org/es6-weak-map/download/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha1-ttofFswswNm+Q+a9v8Xn383zHVM=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "escallmatch": {
+      "version": "1.5.0",
+      "resolved": "http://registry.npm.taobao.org/escallmatch/download/escallmatch-1.5.0.tgz",
+      "integrity": "sha1-UAmdhugJGwkt+N37w/mm+wWgJNA=",
+      "dev": true,
+      "requires": {
+        "call-matcher": "^1.0.0",
+        "esprima": "^2.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "http://registry.npm.taobao.org/esprima/download/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        }
+      }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/escape-html/download/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npm.taobao.org/escodegen/download/escodegen-1.12.0.tgz",
+      "integrity": "sha1-92Pa+ECvFyuzorbdchnA4X9/9UE=",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "http://registry.npm.taobao.org/escope/download/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npm.taobao.org/eslint/download/eslint-4.19.1.tgz",
+      "integrity": "sha1-MtHWU+HZBAiFS/spbwdux+GGowA=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "http://registry.npm.taobao.org/cross-spawn/download/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npm.taobao.org/globals/download/globals-11.12.0.tgz?cache=0&sync_timestamp=1563721993391&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobals%2Fdownload%2Fglobals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-egg": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npm.taobao.org/eslint-config-egg/download/eslint-config-egg-5.1.1.tgz",
+      "integrity": "sha1-CmAb/cQy4QXPnck8fDCebBY6ceM=",
+      "dev": true,
+      "requires": {
+        "babel-eslint": "^7.2.3",
+        "eslint-plugin-import": "^2.6.0",
+        "eslint-plugin-jsx-a11y": "^6.0.0",
+        "eslint-plugin-react": "^7.1.0"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "http://registry.npm.taobao.org/eslint-import-resolver-node/download/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha1-WPFfuDm40FdsqYBBNHaqskcttmo=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npm.taobao.org/eslint-module-utils/download/eslint-module-utils-2.4.1.tgz",
+      "integrity": "sha1-e0Z1h1v5aw2/GyGXdFblux9eAYw=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npm.taobao.org/eslint-plugin-import/download/eslint-plugin-import-2.18.2.tgz",
+      "integrity": "sha1-AvEYC5Cwd7M9RHoXojJs60AKzrY=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.2",
+        "eslint-module-utils": "^2.4.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.0",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.11.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "http://registry.npm.taobao.org/doctrine/download/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz?cache=0&sync_timestamp=1562592096220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisarray%2Fdownload%2Fisarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/load-json-file/download/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
+          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-locate/download/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-try/download/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/path-type/download/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/read-pkg/download/read-pkg-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fread-pkg%2Fdownload%2Fread-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npm.taobao.org/eslint-plugin-jsx-a11y/download/eslint-plugin-jsx-a11y-6.2.3.tgz",
+      "integrity": "sha1-uHKgnV3lGvcKl9se6n3JMwQ3CKo=",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.2.1"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npm.taobao.org/eslint-plugin-react/download/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha1-kRAw3X6YuknhsiCFmVcYRqZr3xM=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npm.taobao.org/eslint-scope/download/eslint-scope-3.7.3.tgz",
+      "integrity": "sha1-u1ByANPRf2AkdjYWC0gmKEsQhTU=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/eslint-visitor-keys/download/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
+      "dev": true
+    },
+    "espower": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/espower/download/espower-2.1.2.tgz",
+      "integrity": "sha1-gk+IeI+f7fTPD5KPXhG7kHzpuRg=",
+      "dev": true,
+      "requires": {
+        "array-find": "^1.0.0",
+        "escallmatch": "^1.5.0",
+        "escodegen": "^1.7.0",
+        "escope": "^3.3.0",
+        "espower-location-detector": "^1.0.0",
+        "espurify": "^1.3.0",
+        "estraverse": "^4.1.0",
+        "source-map": "^0.5.0",
+        "type-name": "^2.0.0"
+      }
+    },
+    "espower-loader": {
+      "version": "1.2.2",
+      "resolved": "http://registry.npm.taobao.org/espower-loader/download/espower-loader-1.2.2.tgz",
+      "integrity": "sha1-7bRsPFmga6yOpzppXIblxaC8gto=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "^1.1.0",
+        "espower-source": "^2.0.0",
+        "minimatch": "^3.0.0",
+        "source-map-support": "^0.4.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "espower-location-detector": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/espower-location-detector/download/espower-location-detector-1.0.0.tgz",
+      "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
+      "dev": true,
+      "requires": {
+        "is-url": "^1.2.1",
+        "path-is-absolute": "^1.0.0",
+        "source-map": "^0.5.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "espower-source": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npm.taobao.org/espower-source/download/espower-source-2.3.0.tgz",
+      "integrity": "sha1-Q+k7LBivUAGL2xvqehJx9KHBJfQ=",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.0.0",
+        "acorn-es7-plugin": "^1.0.10",
+        "convert-source-map": "^1.1.1",
+        "empower-assert": "^1.0.0",
+        "escodegen": "^1.10.0",
+        "espower": "^2.1.1",
+        "estraverse": "^4.0.0",
+        "merge-estraverse-visitors": "^1.0.0",
+        "multi-stage-sourcemap": "^0.2.1",
+        "path-is-absolute": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "espower-typescript": {
+      "version": "9.0.1",
+      "resolved": "http://registry.npm.taobao.org/espower-typescript/download/espower-typescript-9.0.1.tgz",
+      "integrity": "sha1-U2FAdQ+FCfS9xdt0YcC/YAUsBlg=",
+      "dev": true,
+      "requires": {
+        "espower-source": "^2.3.0",
+        "minimatch": "^3.0.3",
+        "source-map-support": "^0.5.9",
+        "ts-node": "^7.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.13.tgz",
+          "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npm.taobao.org/espree/download/espree-3.5.4.tgz",
+      "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "3.1.3",
+      "resolved": "http://registry.npm.taobao.org/esprima/download/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+      "dev": true
+    },
+    "espurify": {
+      "version": "1.8.1",
+      "resolved": "http://registry.npm.taobao.org/espurify/download/espurify-1.8.1.tgz",
+      "integrity": "sha1-V0bGwatC0wLeEL0dW/fw6MBRUFY=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0"
+      }
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/esquery/download/esquery-1.0.1.tgz",
+      "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "http://registry.npm.taobao.org/esrecurse/download/esrecurse-4.2.1.tgz",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "http://registry.npm.taobao.org/estraverse/download/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npm.taobao.org/esutils/download/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "dev": true
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "http://registry.npm.taobao.org/event-emitter/download/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "http://registry.npm.taobao.org/event-stream/download/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/execa/download/execa-1.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-1.0.0.tgz",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "http://registry.npm.taobao.org/expand-brackets/download/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/extend/download/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
+    "extend2": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/extend2/download/extend2-1.0.0.tgz",
+      "integrity": "sha1-BCWpibTawqSGoyJX9RQBA3Vqejw=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npm.taobao.org/external-editor/download/external-editor-2.2.0.tgz?cache=0&sync_timestamp=1562602052556&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexternal-editor%2Fdownload%2Fexternal-editor-2.2.0.tgz",
+      "integrity": "sha1-BFURz9jRM/OEZnPRBHwVTiFK09U=",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "http://registry.npm.taobao.org/extglob/download/extglob-2.0.4.tgz",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-1.1.0.tgz?cache=0&sync_timestamp=1562517919182&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffast-deep-equal%2Fdownload%2Ffast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npm.taobao.org/fast-glob/download/fast-glob-2.2.7.tgz",
+      "integrity": "sha1-aVOFfDr6R1//ku5gFdUtpwpM050=",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/fast-json-stable-stringify/download/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "http://registry.npm.taobao.org/fast-levenshtein/download/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/figures/download/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/file-entry-cache/download/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/file-uri-to-path/download/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "http://registry.npm.taobao.org/fill-range/download/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "http://registry.npm.taobao.org/flat/download/flat-4.1.0.tgz",
+      "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "http://registry.npm.taobao.org/is-buffer/download/is-buffer-2.0.3.tgz",
+          "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU=",
+          "dev": true
+        }
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "http://registry.npm.taobao.org/flat-cache/download/flat-cache-1.3.4.tgz",
+      "integrity": "sha1-LC73dSXMKSkAff/6HdMUqpyd7m8=",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/for-in/download/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npm.taobao.org/form-data/download/form-data-2.5.0.tgz",
+      "integrity": "sha1-CU7DWdxLVefWLg20rNduif6HTTc=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/formidable/download/formidable-1.2.1.tgz",
+      "integrity": "sha1-cPt8oCkO5v+WEJBBX0s989IIJlk=",
+      "dev": true
+    },
+    "formstream": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/formstream/download/formstream-1.1.0.tgz",
+      "integrity": "sha1-UfOXDyYTbrCtRDBN5M67UCB7RHk=",
+      "dev": true,
+      "requires": {
+        "destroy": "^1.0.4",
+        "mime": "^1.3.4",
+        "pause-stream": "~0.0.11"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/fragment-cache/download/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "http://registry.npm.taobao.org/fresh/download/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "http://registry.npm.taobao.org/from/download/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+      "dev": true
+    },
+    "fs-readdir-recursive": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/fs-readdir-recursive/download/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npm.taobao.org/fsevents/download/fsevents-1.2.9.tgz",
+      "integrity": "sha1-P17WZYPM1vQAtaANtvfoYTY+OI8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "ftp": {
+      "version": "0.3.10",
+      "resolved": "http://registry.npm.taobao.org/ftp/download/ftp-0.3.10.tgz",
+      "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.x",
+        "xregexp": "2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-1.1.14.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/function-bind/download/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/functional-red-black-tree/download/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/get-caller-file/download/get-caller-file-1.0.3.tgz",
+      "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+      "dev": true
+    },
+    "get-ready": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/get-ready/download/get-ready-2.0.1.tgz",
+      "integrity": "sha1-pIxBh1PjnPTQHzpCDPG3V93MZI8=",
+      "dev": true,
+      "requires": {
+        "is-type-of": "^1.0.0"
+      }
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "http://registry.npm.taobao.org/get-stream/download/get-stream-4.1.0.tgz",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-uri": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/get-uri/download/get-uri-2.0.3.tgz",
+      "integrity": "sha1-+hM1Iml4HXUWLG/IE8npBTI/urU=",
+      "dev": true,
+      "requires": {
+        "data-uri-to-buffer": "2",
+        "debug": "4",
+        "extend": "~3.0.2",
+        "file-uri-to-path": "1",
+        "ftp": "~0.3.10",
+        "readable-stream": "3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "http://registry.npm.taobao.org/get-value/download/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npm.taobao.org/glob/download/glob-7.1.4.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglob%2Fdownload%2Fglob-7.1.4.tgz",
+      "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/glob-parent/download/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.taobao.org/glob-to-regexp/download/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npm.taobao.org/globals/download/globals-9.18.0.tgz?cache=0&sync_timestamp=1563721993391&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobals%2Fdownload%2Fglobals-9.18.0.tgz",
+      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "dev": true
+    },
+    "globby": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npm.taobao.org/globby/download/globby-8.0.2.tgz?cache=0&sync_timestamp=1562335642755&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fglobby%2Fdownload%2Fglobby-8.0.2.tgz",
+      "integrity": "sha1-VpdhnM2VxSdduy1vqkIIfBqUHY0=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "dir-glob": "2.0.0",
+        "fast-glob": "^2.0.2",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      }
+    },
+    "graceful": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/graceful/download/graceful-1.0.2.tgz",
+      "integrity": "sha1-p1EbDSfoRANnRsTOjk8UacD6LqY=",
+      "dev": true,
+      "requires": {
+        "humanize-ms": "^1.2.1",
+        "ps-tree": "^1.1.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npm.taobao.org/graceful-fs/download/graceful-fs-4.2.1.tgz",
+      "integrity": "sha1-HB8MNkiCyGj1v/ZRIUYygzahGx0=",
+      "dev": true
+    },
+    "graceful-process": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/graceful-process/download/graceful-process-1.2.0.tgz",
+      "integrity": "sha1-WyvW7aO1l3fbaoqTMueeYkYIbYU=",
+      "dev": true,
+      "requires": {
+        "is-type-of": "^1.2.0",
+        "once": "^1.4.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "http://registry.npm.taobao.org/growl/download/growl-1.10.5.tgz",
+      "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/has/download/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/has-ansi/download/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/has-symbols/download/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/has-value/download/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/has-values/download/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/he/download/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+      "dev": true
+    },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/header-case/download/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/home-or-tmp/download/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npm.taobao.org/hosted-git-info/download/hosted-git-info-2.8.4.tgz?cache=0&sync_timestamp=1565653465928&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhosted-git-info%2Fdownload%2Fhosted-git-info-2.8.4.tgz",
+      "integrity": "sha1-RBGauvS8ZGkqFqzjRwD+2cA+JUY=",
+      "dev": true
+    },
+    "http-assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npm.taobao.org/http-assert/download/http-assert-1.4.1.tgz",
+      "integrity": "sha1-xfcl1neqfoc+9zYZm4lobM6zeHg=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.7.2"
+      }
+    },
+    "http-errors": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.3.tgz?cache=0&sync_timestamp=1561418493658&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-errors%2Fdownload%2Fhttp-errors-1.7.3.tgz",
+      "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      }
+    },
+    "http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/http-proxy-agent/download/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
+      "dev": true,
+      "requires": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npm.taobao.org/https-proxy-agent/download/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha1-Jx6o6Q+DasnxGdrM05wZ/337B5M=",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      }
+    },
+    "humanize-bytes": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/humanize-bytes/download/humanize-bytes-1.0.1.tgz",
+      "integrity": "sha1-IfV8oxjSEaAG3JeYpGWE+vLZfpw=",
+      "dev": true,
+      "requires": {
+        "bytes": "~2.2.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npm.taobao.org/bytes/download/bytes-2.2.0.tgz",
+          "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
+          "dev": true
+        }
+      }
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/humanize-ms/download/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npm.taobao.org/iconv-lite/download/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "http://registry.npm.taobao.org/ieee754/download/ieee754-1.1.13.tgz",
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npm.taobao.org/ignore/download/ignore-3.3.10.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fignore%2Fdownload%2Fignore-3.3.10.tgz",
+      "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "http://registry.npm.taobao.org/imurmurhash/download/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "http://registry.npm.taobao.org/indexof/download/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflation": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/inflation/download/inflation-2.0.0.tgz",
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8=",
+      "dev": true
+    },
+    "inflection": {
+      "version": "1.12.0",
+      "resolved": "http://registry.npm.taobao.org/inflection/download/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.taobao.org/inflight/download/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "http://registry.npm.taobao.org/ini/download/ini-1.3.5.tgz",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npm.taobao.org/inquirer/download/inquirer-3.3.0.tgz",
+      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "inspector-proxy": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/inspector-proxy/download/inspector-proxy-1.2.1.tgz",
+      "integrity": "sha1-hw0vQZFQF4tcN2WyhSrnKJvlQHk=",
+      "dev": true,
+      "requires": {
+        "cfork": "^1.6.1",
+        "debug": "^3.0.1",
+        "tcp-proxy.js": "^1.0.5",
+        "urllib": "^2.24.0"
+      }
+    },
+    "intelli-espower-loader": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/intelli-espower-loader/download/intelli-espower-loader-1.0.1.tgz",
+      "integrity": "sha1-LHsDFGvB1GvyENCgOXxckatMorA=",
+      "dev": true,
+      "requires": {
+        "espower-loader": "^1.0.0"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "http://registry.npm.taobao.org/invariant/download/invariant-2.2.4.tgz",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/invert-kv/download/invert-kv-2.0.0.tgz",
+      "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
+      "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "http://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/is-arrayish/download/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "http://registry.npm.taobao.org/is-buffer/download/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "http://registry.npm.taobao.org/is-callable/download/is-callable-1.1.4.tgz",
+      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "dev": true
+    },
+    "is-class-hotfix": {
+      "version": "0.0.6",
+      "resolved": "http://registry.npm.taobao.org/is-class-hotfix/download/is-class-hotfix-0.0.6.tgz",
+      "integrity": "sha1-pSfTH7IyeSgd3l84XHe13nCnJDU=",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/is-date-object/download/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/is-extglob/download/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/is-finite/download/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/is-generator/download/is-generator-1.0.3.tgz",
+      "integrity": "sha1-wUwhBX7TbjKNuANHlmxpP4hjifM=",
+      "dev": true
+    },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "http://registry.npm.taobao.org/is-generator-function/download/is-generator-function-1.0.7.tgz",
+      "integrity": "sha1-0hMuUpuwAAp/gHlNS99c1eWBNSI=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "http://registry.npm.taobao.org/is-glob/download/is-glob-4.0.1.tgz",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/is-lower-case/download/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
+    "is-nan": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/is-nan/download/is-nan-1.2.1.tgz",
+      "integrity": "sha1-n69ltvttskt/XAYoR16nH5iEAeI=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.1"
+      }
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/is-number/download/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/is-obj/download/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npm.taobao.org/is-plain-object/download/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/is-promise/download/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "http://registry.npm.taobao.org/is-regex/download/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/is-resolvable/download/is-resolvable-1.1.0.tgz",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npm.taobao.org/is-stream/download/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/is-symbol/download/is-symbol-1.0.2.tgz",
+      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "is-type-of": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/is-type-of/download/is-type-of-1.2.1.tgz",
+      "integrity": "sha1-4mPsOFes608oxHEw7HjbCakg+MU=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "^1.0.2",
+        "is-class-hotfix": "~0.0.6",
+        "isstream": "~0.1.2"
+      }
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/is-upper-case/download/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
+    },
+    "is-url": {
+      "version": "1.2.4",
+      "resolved": "http://registry.npm.taobao.org/is-url/download/is-url-1.2.4.tgz",
+      "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/is-utf8/download/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/is-windows/download/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-0.0.1.tgz?cache=0&sync_timestamp=1562592096220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisarray%2Fdownload%2Fisarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/isexe/download/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npm.taobao.org/isobject/download/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/isstream/download/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npm.taobao.org/istanbul-lib-coverage/download/istanbul-lib-coverage-2.0.5.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fistanbul-lib-coverage%2Fdownload%2Fistanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npm.taobao.org/istanbul-lib-instrument/download/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      }
+    },
+    "jest-changed-files": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npm.taobao.org/jest-changed-files/download/jest-changed-files-24.8.0.tgz",
+      "integrity": "sha1-fn6yHPaHWHqF5Q89JJ0TJ+FbFXs=",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npm.taobao.org/js-tokens/download/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "http://registry.npm.taobao.org/js-yaml/download/js-yaml-3.13.1.tgz",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "http://registry.npm.taobao.org/esprima/download/esprima-4.0.1.tgz",
+          "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+          "dev": true
+        }
+      }
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/json-parse-better-errors/download/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "http://registry.npm.taobao.org/json-schema-traverse/download/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/json-stable-stringify-without-jsonify/download/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "http://registry.npm.taobao.org/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonp-body": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/jsonp-body/download/jsonp-body-1.0.0.tgz",
+      "integrity": "sha1-5hD7b86nnPDMnye6p7Vjd9SwuzY=",
+      "dev": true
+    },
+    "jsx-ast-utils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npm.taobao.org/jsx-ast-utils/download/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha1-TUlz6/i50oN+6RqCCMxm86J3bPs=",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
+      }
+    },
+    "keygrip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npm.taobao.org/keygrip/download/keygrip-1.0.3.tgz",
+      "integrity": "sha1-OZ1wnwrtK6sKBZ4M3TpQI6BT4dw=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-6.0.2.tgz",
+      "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE=",
+      "dev": true
+    },
+    "ko-sleep": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/ko-sleep/download/ko-sleep-1.0.3.tgz",
+      "integrity": "sha1-KKKgoUhei39BX/SI3uF9JHiKsII=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
+    "koa": {
+      "version": "2.7.0",
+      "resolved": "http://registry.npm.taobao.org/koa/download/koa-2.7.0.tgz",
+      "integrity": "sha1-fgCENQaUK52CxswzdJ9lfG5eet8=",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.7.1",
+        "debug": "~3.1.0",
+        "delegates": "^1.0.0",
+        "depd": "^1.1.2",
+        "destroy": "^1.0.4",
+        "error-inject": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^1.2.0",
+        "koa-is-json": "^1.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "koa-compose": {
+          "version": "4.1.0",
+          "resolved": "http://registry.npm.taobao.org/koa-compose/download/koa-compose-4.1.0.tgz",
+          "integrity": "sha1-UHMGuTcZAdtBEhyBLpI9DWfT6Hc=",
+          "dev": true
+        }
+      }
+    },
+    "koa-bodyparser": {
+      "version": "4.2.1",
+      "resolved": "http://registry.npm.taobao.org/koa-bodyparser/download/koa-bodyparser-4.2.1.tgz",
+      "integrity": "sha1-TX2stebbEQZkm1ldnlzLFYtvOyk=",
+      "dev": true,
+      "requires": {
+        "co-body": "^6.0.0",
+        "copy-to": "^2.0.1"
+      }
+    },
+    "koa-compose": {
+      "version": "3.2.1",
+      "resolved": "http://registry.npm.taobao.org/koa-compose/download/koa-compose-3.2.1.tgz",
+      "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.1.0"
+      }
+    },
+    "koa-convert": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/koa-convert/download/koa-convert-1.2.0.tgz",
+      "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "koa-compose": "^3.0.0"
+      }
+    },
+    "koa-is-json": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/koa-is-json/download/koa-is-json-1.0.0.tgz",
+      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ=",
+      "dev": true
+    },
+    "koa-locales": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npm.taobao.org/koa-locales/download/koa-locales-1.12.0.tgz",
+      "integrity": "sha1-DCpwgpR6kmOvwlunO2ivaiIB8J0=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.0",
+        "humanize-ms": "^1.2.0",
+        "ini": "^1.3.4",
+        "object-assign": "^4.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "koa-onerror": {
+      "version": "4.1.0",
+      "resolved": "http://registry.npm.taobao.org/koa-onerror/download/koa-onerror-4.1.0.tgz",
+      "integrity": "sha1-eUnHZRlB5nsRgTvx+tA8LTRHCxw=",
+      "requires": {
+        "escape-html": "^1.0.3",
+        "stream-wormhole": "^1.1.0"
+      }
+    },
+    "koa-override": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/koa-override/download/koa-override-3.0.0.tgz",
+      "integrity": "sha1-oU+oSXW6sIxXMKQ3iIgxZPT4Ghw=",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2"
+      }
+    },
+    "koa-range": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.taobao.org/koa-range/download/koa-range-0.3.0.tgz",
+      "integrity": "sha1-NYjjSWRzqDmhvSZNKkKx2FvX/qw=",
+      "dev": true,
+      "requires": {
+        "stream-slice": "^0.1.2"
+      }
+    },
+    "koa-session": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npm.taobao.org/koa-session/download/koa-session-5.12.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fkoa-session%2Fdownload%2Fkoa-session-5.12.2.tgz",
+      "integrity": "sha1-qVSTYXUehLE353i7k99e61FHjB8=",
+      "dev": true,
+      "requires": {
+        "crc": "^3.4.4",
+        "debug": "^3.1.0",
+        "is-type-of": "^1.0.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "koa-static-cache": {
+      "version": "5.1.2",
+      "resolved": "http://registry.npm.taobao.org/koa-static-cache/download/koa-static-cache-5.1.2.tgz",
+      "integrity": "sha1-SbWSAHFXsWT16d9bJ24wXIvlAWo=",
+      "dev": true,
+      "requires": {
+        "compressible": "^2.0.6",
+        "debug": "^3.1.0",
+        "fs-readdir-recursive": "^1.0.0",
+        "mime-types": "^2.1.8",
+        "mz": "^2.7.0"
+      }
+    },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/lcid/download/lcid-2.0.0.tgz",
+      "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.taobao.org/levn/download/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npm.taobao.org/load-json-file/download/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npm.taobao.org/lodash/download/lodash-4.17.15.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flodash%2Fdownload%2Flodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/log-symbols/download/log-symbols-2.2.0.tgz",
+      "integrity": "sha1-V0Dhxdbw39pK2TI7UzIQfva0xAo=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "http://registry.npm.taobao.org/long/download/long-4.0.0.tgz",
+      "integrity": "sha1-mntxz7fTYaGU6lVSQckvdGjVvyg=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npm.taobao.org/loose-envify/download/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "http://registry.npm.taobao.org/lower-case/download/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/lower-case-first/download/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.2"
+      }
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "http://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "http://registry.npm.taobao.org/make-error/download/make-error-1.3.5.tgz",
+      "integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg=",
+      "dev": true
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "http://registry.npm.taobao.org/map-age-cleaner/download/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "http://registry.npm.taobao.org/map-cache/download/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.taobao.org/map-stream/download/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/map-visit/download/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "matcher": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npm.taobao.org/matcher/download/matcher-1.1.1.tgz",
+      "integrity": "sha1-UdgwHhOPhAmCszixFrsMCa9iwcI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.4"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npm.taobao.org/media-typer/download/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npm.taobao.org/mem/download/mem-4.3.0.tgz",
+      "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge-estraverse-visitors": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/merge-estraverse-visitors/download/merge-estraverse-visitors-1.0.0.tgz",
+      "integrity": "sha1-65aDOLXe1c7tgs7AMH3sui2OqZQ=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "merge2": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npm.taobao.org/merge2/download/merge2-1.2.4.tgz?cache=0&sync_timestamp=1564568903369&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmerge2%2Fdownload%2Fmerge2-1.2.4.tgz",
+      "integrity": "sha1-ySaVieaIWmDPgGBdlSLUtnymRuM=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/methods/download/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npm.taobao.org/micromatch/download/micromatch-3.1.10.tgz",
+      "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1560034758817&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
+      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "http://registry.npm.taobao.org/mime-db/download/mime-db-1.40.0.tgz",
+      "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "http://registry.npm.taobao.org/mime-types/download/mime-types-2.1.24.tgz",
+      "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/mimic-fn/download/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://registry.npm.taobao.org/minimatch/download/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npm.taobao.org/mixin-deep/download/mixin-deep-1.3.2.tgz?cache=0&sync_timestamp=1561436244196&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmixin-deep%2Fdownload%2Fmixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npm.taobao.org/mkdirp/download/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mm": {
+      "version": "2.5.0",
+      "resolved": "http://registry.npm.taobao.org/mm/download/mm-2.5.0.tgz",
+      "integrity": "sha1-37mTdiwUaLWRxMT81H3/Re0BN4o=",
+      "dev": true,
+      "requires": {
+        "is-type-of": "^1.0.0",
+        "ko-sleep": "^1.0.2",
+        "muk-prop": "^1.0.0",
+        "thenify": "^3.2.1"
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "http://registry.npm.taobao.org/moment/download/moment-2.24.0.tgz",
+      "integrity": "sha1-DQVdU/UFKqZTyfbraLtdEr9cK1s=",
+      "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npm.taobao.org/moment-timezone/download/moment-timezone-0.5.26.tgz",
+      "integrity": "sha1-wCZ8oJroRjGqPcM/Zb7b5ujg13I=",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "muk-prop": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/muk-prop/download/muk-prop-1.2.1.tgz",
+      "integrity": "sha1-QPo9bpNVOyAWqft32JGFaMV64U0=",
+      "dev": true
+    },
+    "multi-stage-sourcemap": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/multi-stage-sourcemap/download/multi-stage-sourcemap-0.2.1.tgz",
+      "integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.1.34"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/multimatch/download/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "dev": true,
+      "requires": {
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
+      }
+    },
+    "mustache": {
+      "version": "2.3.2",
+      "resolved": "http://registry.npm.taobao.org/mustache/download/mustache-2.3.2.tgz",
+      "integrity": "sha1-ptTZw/kdEzWauImoEpVPkjCj0MU="
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "http://registry.npm.taobao.org/mute-stream/download/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "http://registry.npm.taobao.org/mz/download/mz-2.7.0.tgz",
+      "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "mz-modules": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/mz-modules/download/mz-modules-2.1.0.tgz",
+      "integrity": "sha1-f1KYd6/Q1C9AmnRjuWmG1hz7z5Y=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.2",
+        "ko-sleep": "^1.0.3",
+        "mkdirp": "^0.5.1",
+        "pump": "^3.0.0",
+        "rimraf": "^2.6.1"
+      }
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npm.taobao.org/nan/download/nan-2.14.0.tgz",
+      "integrity": "sha1-eBj3IgJ7JFmobwKV1DTR/CM2xSw=",
+      "dev": true,
+      "optional": true
+    },
+    "nanoid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npm.taobao.org/nanoid/download/nanoid-2.0.3.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnanoid%2Fdownload%2Fnanoid-2.0.3.tgz",
+      "integrity": "sha1-3emZ4XO8nXvS7idGuJkJremOB14=",
+      "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "http://registry.npm.taobao.org/nanomatch/download/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npm.taobao.org/natural-compare/download/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "ndir": {
+      "version": "0.1.5",
+      "resolved": "http://registry.npm.taobao.org/ndir/download/ndir-0.1.5.tgz",
+      "integrity": "sha1-EgiR12l7u+ghTP7/CWAgYNNFRVg=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npm.taobao.org/negotiator/download/negotiator-0.6.2.tgz",
+      "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
+      "dev": true
+    },
+    "netmask": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.taobao.org/netmask/download/netmask-1.0.6.tgz",
+      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/next-tick/download/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "http://registry.npm.taobao.org/nice-try/download/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+      "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "http://registry.npm.taobao.org/no-case/download/no-case-2.3.2.tgz",
+      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npm.taobao.org/node-environment-flags/download/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha1-+pMCdfW/Xa4YjWGSsktMi7rD12o=",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "node-homedir": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/node-homedir/download/node-homedir-1.1.1.tgz",
+      "integrity": "sha1-c22wtg47uoq6aN+ZJ95Ap6q+EHU=",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "http://registry.npm.taobao.org/normalize-package-data/download/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/normalize-path/download/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.taobao.org/npm-run-path/download/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/number-is-nan/download/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nunjucks": {
+      "version": "3.2.0",
+      "resolved": "http://registry.npm.taobao.org/nunjucks/download/nunjucks-3.2.0.tgz",
+      "integrity": "sha1-U+lfQ8lVXoIuiVAAiiAbEALUmTM=",
+      "dev": true,
+      "requires": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "chokidar": "^2.0.0",
+        "yargs": "^3.32.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "http://registry.npm.taobao.org/cliui/download/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/invert-kv/download/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/lcid/download/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-1.4.0.tgz?cache=0&sync_timestamp=1560274285880&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fos-locale%2Fdownload%2Fos-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "http://registry.npm.taobao.org/y18n/download/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
+    "nyc": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npm.taobao.org/nyc/download/nyc-13.3.0.tgz",
+      "integrity": "sha1-2k2+kanIuerT9PM0THbzU+PHjHU=",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^3.0.1",
+        "convert-source-map": "^1.6.0",
+        "find-cache-dir": "^2.0.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.3",
+        "istanbul-lib-hook": "^2.0.3",
+        "istanbul-lib-instrument": "^3.1.0",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.2",
+        "istanbul-reports": "^2.1.1",
+        "make-dir": "^1.3.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.1.0",
+        "uuid": "^3.3.2",
+        "yargs": "^12.0.5",
+        "yargs-parser": "^11.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^2.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "caching-transform": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hasha": "^3.0.0",
+            "make-dir": "^1.3.0",
+            "package-hash": "^3.0.0",
+            "write-file-atomic": "^2.3.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commander": {
+          "version": "2.17.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^2.5.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hasha": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-stream": "^1.0.1"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "^1.0.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "supports-color": "^6.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "6.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.1.0"
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "map-age-cleaner": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-defer": "^1.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.10",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-defer": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-is-promise": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-hash": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "hasha": "^3.0.0",
+            "lodash.flattendeep": "^4.4.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-error": "^4.0.1"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "3.4.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "http://registry.npm.taobao.org/object-assign/download/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.taobao.org/object-copy/download/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/object-keys/download/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/object-visit/download/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "http://registry.npm.taobao.org/object.assign/download/object.assign-4.1.0.tgz",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/object.entries/download/object.entries-1.1.0.tgz",
+      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/object.fromentries/download/object.fromentries-2.0.0.tgz",
+      "integrity": "sha1-SaVD2SFR+Cd7OslgDx6TCxidMKs=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/object.getownpropertydescriptors/download/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npm.taobao.org/object.pick/download/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/object.values/download/object.values-1.1.0.tgz",
+      "integrity": "sha1-v2gQ712j5TJXkOqqK+IT6oRiTak=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npm.taobao.org/on-finished/download/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npm.taobao.org/once/download/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/onetime/download/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npm.taobao.org/mimic-fn/download/mimic-fn-1.2.0.tgz",
+          "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+          "dev": true
+        }
+      }
+    },
+    "only": {
+      "version": "0.0.2",
+      "resolved": "http://registry.npm.taobao.org/only/download/only-0.0.2.tgz",
+      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
+      "dev": true
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "http://registry.npm.taobao.org/optionator/download/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/os-homedir/download/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-3.1.0.tgz?cache=0&sync_timestamp=1560274285880&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fos-locale%2Fdownload%2Fos-locale-3.1.0.tgz",
+      "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "os-name": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/os-name/download/os-name-1.0.3.tgz",
+      "integrity": "sha1-GzefZINa98Wn9JizV8uVIVwVnt8=",
+      "dev": true,
+      "requires": {
+        "osx-release": "^1.0.0",
+        "win-release": "^1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/os-tmpdir/download/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osx-release": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/osx-release/download/osx-release-1.1.0.tgz",
+      "integrity": "sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/p-defer/download/p-defer-1.0.0.tgz?cache=0&sync_timestamp=1559922734651&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fp-defer%2Fdownload%2Fp-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/p-finally/download/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/p-is-promise/download/p-is-promise-2.1.0.tgz",
+      "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-2.2.0.tgz",
+      "integrity": "sha1-QXyZQeYCepq8ulCS3SkE4lW1+8I=",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/p-locate/download/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/p-try/download/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+      "dev": true
+    },
+    "pac-proxy-agent": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/pac-proxy-agent/download/pac-proxy-agent-3.0.0.tgz",
+      "integrity": "sha1-EdV4tyoWStdL+dW6yf9GKjgoJDI=",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "get-uri": "^2.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "pac-resolver": "^3.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "^4.0.1"
+      }
+    },
+    "pac-resolver": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/pac-resolver/download/pac-resolver-3.0.0.tgz",
+      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
+      "dev": true,
+      "requires": {
+        "co": "^4.6.0",
+        "degenerator": "^1.0.4",
+        "ip": "^1.1.5",
+        "netmask": "^1.0.6",
+        "thunkify": "^2.1.2"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/param-case/download/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "http://registry.npm.taobao.org/parseurl/download/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
+      "dev": true
+    },
+    "pascal-case": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/pascal-case/download/pascal-case-2.0.1.tgz",
+      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
+      }
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npm.taobao.org/pascalcase/download/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/path-case/download/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/path-dirname/download/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/path-is-inside/download/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/path-key/download/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.taobao.org/path-parse/download/path-parse-1.0.6.tgz",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "http://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/path-type/download/path-type-3.0.0.tgz",
+      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "http://registry.npm.taobao.org/pause-stream/download/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
+    "pedding": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/pedding/download/pedding-1.1.0.tgz",
+      "integrity": "sha1-97E4wojUvVhOraEhX1vZJPHh5mc=",
+      "dev": true
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/pify/download/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "http://registry.npm.taobao.org/pinkie/download/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/pinkie-promise/download/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/pkg-dir/download/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/locate-path/download/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "http://registry.npm.taobao.org/p-limit/download/p-limit-1.3.0.tgz",
+          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-locate/download/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/p-try/download/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
+      }
+    },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "http://registry.npm.taobao.org/platform/download/platform-1.3.5.tgz",
+      "integrity": "sha1-+2lYxpbgfikY0u7aDwvJRI1zNEQ=",
+      "dev": true
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npm.taobao.org/pluralize/download/pluralize-7.0.0.tgz",
+      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
+      "dev": true
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npm.taobao.org/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "power-assert": {
+      "version": "1.6.1",
+      "resolved": "http://registry.npm.taobao.org/power-assert/download/power-assert-1.6.1.tgz",
+      "integrity": "sha1-soy8Aq6Aiv0UMdDNUJOjmsWlsf4=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "empower": "^1.3.1",
+        "power-assert-formatter": "^1.4.1",
+        "universal-deep-strict-equal": "^1.2.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "power-assert-context-formatter": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-context-formatter/download/power-assert-context-formatter-1.2.0.tgz",
+      "integrity": "sha1-j75yaSKI7FpyA83yFci4OKYGHSo=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "power-assert-context-traversal": "^1.2.0"
+      }
+    },
+    "power-assert-context-reducer-ast": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-context-reducer-ast/download/power-assert-context-reducer-ast-1.2.0.tgz",
+      "integrity": "sha1-x8ocnjmm+3F/esX+nnbhkr9SXfM=",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.0.0",
+        "acorn-es7-plugin": "^1.0.12",
+        "core-js": "^2.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.2.0"
+      }
+    },
+    "power-assert-context-traversal": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-context-traversal/download/power-assert-context-traversal-1.2.0.tgz",
+      "integrity": "sha1-9ucUVLr2QN5cHJwnA0n1yasLLpQ=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "estraverse": "^4.1.0"
+      }
+    },
+    "power-assert-formatter": {
+      "version": "1.4.1",
+      "resolved": "http://registry.npm.taobao.org/power-assert-formatter/download/power-assert-formatter-1.4.1.tgz",
+      "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "power-assert-context-formatter": "^1.0.7",
+        "power-assert-context-reducer-ast": "^1.0.7",
+        "power-assert-renderer-assertion": "^1.0.7",
+        "power-assert-renderer-comparison": "^1.0.7",
+        "power-assert-renderer-diagram": "^1.0.7",
+        "power-assert-renderer-file": "^1.0.7"
+      }
+    },
+    "power-assert-renderer-assertion": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-renderer-assertion/download/power-assert-renderer-assertion-1.2.0.tgz",
+      "integrity": "sha1-Pbb/zaEGs3vB4GQyrQ10imgrFHo=",
+      "dev": true,
+      "requires": {
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.2.0"
+      }
+    },
+    "power-assert-renderer-base": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/power-assert-renderer-base/download/power-assert-renderer-base-1.1.1.tgz",
+      "integrity": "sha1-lqZQxv0F7hvB9mtUrWFELIs/Y+s=",
+      "dev": true
+    },
+    "power-assert-renderer-comparison": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-renderer-comparison/download/power-assert-renderer-comparison-1.2.0.tgz",
+      "integrity": "sha1-5PiBEyJaab6KpYbq0FrvmUYsBJU=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "diff-match-patch": "^1.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "stringifier": "^1.3.0",
+        "type-name": "^2.0.1"
+      }
+    },
+    "power-assert-renderer-diagram": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-renderer-diagram/download/power-assert-renderer-diagram-1.2.0.tgz",
+      "integrity": "sha1-N/ZuhULlZ3xbWObXKwHA2aMOIhk=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.2.0",
+        "stringifier": "^1.3.0"
+      }
+    },
+    "power-assert-renderer-file": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-renderer-file/download/power-assert-renderer-file-1.2.0.tgz",
+      "integrity": "sha1-P0vr2eFFXXXPKsVB57tRWofUzks=",
+      "dev": true,
+      "requires": {
+        "power-assert-renderer-base": "^1.1.1"
+      }
+    },
+    "power-assert-util-string-width": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/power-assert-util-string-width/download/power-assert-util-string-width-1.2.0.tgz",
+      "integrity": "sha1-bgbV41gbuHbF03fFMQn/+pW9kaA=",
+      "dev": true,
+      "requires": {
+        "eastasianwidth": "^0.2.0"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/prelude-ls/download/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "printable": {
+      "version": "0.0.3",
+      "resolved": "http://registry.npm.taobao.org/printable/download/printable-0.0.3.tgz",
+      "integrity": "sha1-9lPLObIUt4BJrhQD4vsF10ptUOA=",
+      "dev": true
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "http://registry.npm.taobao.org/private/download/private-0.1.8.tgz",
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npm.taobao.org/process-nextick-args/download/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "http://registry.npm.taobao.org/progress/download/progress-2.0.3.tgz",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "dev": true
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "http://registry.npm.taobao.org/prop-types/download/prop-types-15.7.2.tgz",
+      "integrity": "sha1-UsQedbjIfnK52TYOAga5ncv/psU=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
+    "proxy-agent": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/proxy-agent/download/proxy-agent-3.1.0.tgz",
+      "integrity": "sha1-PPhu6RHJSHTeQ1nzfv2d4lFXwRM=",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "pac-proxy-agent": "^3.0.0",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^4.0.1"
+      }
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/proxy-from-env/download/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/ps-tree/download/ps-tree-1.2.0.tgz",
+      "integrity": "sha1-XnQluJUIc2zdTyIk0Cj3uz9yLr0=",
+      "dev": true,
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/pseudomap/download/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/pump/download/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "qs": {
+      "version": "6.7.0",
+      "resolved": "http://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz",
+      "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
+      "dev": true
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/random-bytes/download/random-bytes-1.0.0.tgz",
+      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npm.taobao.org/raw-body/download/raw-body-2.4.1.tgz",
+      "integrity": "sha1-MKyC+Yu1rowVLmcUnayNVRU7Fow=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.3",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
+    },
+    "react-is": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npm.taobao.org/react-is/download/react-is-16.9.0.tgz?cache=0&sync_timestamp=1565317930066&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freact-is%2Fdownload%2Freact-is-16.9.0.tgz",
+      "integrity": "sha1-IcqVYTmarQ/xp3AcAWg+jKmB7cs=",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.taobao.org/read-pkg/download/read-pkg-3.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fread-pkg%2Fdownload%2Fread-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-4.0.0.tgz",
+      "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "read-pkg": "^3.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.4.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-3.4.0.tgz",
+      "integrity": "sha1-pRwmdUZY4KPCHb9ZFjvUW6b0R/w=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.2.0.tgz",
+          "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.3.0.tgz",
+          "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1562457210009&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
+      "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz?cache=0&sync_timestamp=1562592096220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisarray%2Fdownload%2Fisarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-2.3.6.tgz",
+          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "ready-callback": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/ready-callback/download/ready-callback-2.1.0.tgz",
+      "integrity": "sha1-44Kp4zpWi413HgTvTvDrAtPfp+A=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.0",
+        "get-ready": "^2.0.0",
+        "once": "^1.4.0",
+        "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "http://registry.npm.taobao.org/regenerate/download/regenerate-1.4.0.tgz",
+      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npm.taobao.org/regenerator-runtime/download/regenerator-runtime-0.11.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fregenerator-runtime%2Fdownload%2Fregenerator-runtime-0.11.1.tgz",
+      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npm.taobao.org/regenerator-transform/download/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/regex-not/download/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/regexpp/download/regexpp-1.1.0.tgz",
+      "integrity": "sha1-DjUW3Qt5BPQT0tQZPc5GGMOmias=",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/regexpu-core/download/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npm.taobao.org/regjsgen/download/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "http://registry.npm.taobao.org/regjsparser/download/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "http://registry.npm.taobao.org/jsesc/download/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/remove-trailing-separator/download/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/repeat-element/download/repeat-element-1.1.3.tgz",
+      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "http://registry.npm.taobao.org/repeat-string/download/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "http://registry.npm.taobao.org/repeating/download/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/require-directory/download/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/require-main-filename/download/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/require-uncached/download/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npm.taobao.org/resolve/download/resolve-1.12.0.tgz?cache=0&sync_timestamp=1564641434608&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fresolve%2Fdownload%2Fresolve-1.12.0.tgz",
+      "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-files": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/resolve-files/download/resolve-files-1.0.2.tgz",
+      "integrity": "sha1-WnIRi5L6c5T/LYYF0fw3Ppw+kO8=",
+      "dev": true,
+      "requires": {
+        "crequire": "^1.8.0",
+        "debug": "^2.6.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/resolve-from/download/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/resolve-url/download/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/restore-cursor/download/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "http://registry.npm.taobao.org/ret/download/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "http://registry.npm.taobao.org/rimraf/download/rimraf-2.6.3.tgz",
+      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "rndm": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/rndm/download/rndm-1.2.0.tgz",
+      "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=",
+      "dev": true
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "http://registry.npm.taobao.org/run-async/download/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "http://registry.npm.taobao.org/rx-lite/download/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "http://registry.npm.taobao.org/rx-lite-aggregates/download/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npm.taobao.org/safe-buffer/download/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/safe-regex/download/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safe-timers": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/safe-timers/download/safe-timers-1.1.0.tgz",
+      "integrity": "sha1-xYroMl2407BnMi8KTvOgytZ6rYM=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/safer-buffer/download/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "scmp": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/scmp/download/scmp-2.0.0.tgz",
+      "integrity": "sha1-JHEQ7yLM+JexOj8KvdtSeCOTzWo=",
+      "dev": true
+    },
+    "sdk-base": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npm.taobao.org/sdk-base/download/sdk-base-3.6.0.tgz",
+      "integrity": "sha1-fO4fo6gf3GGywg0RMMh2X42Q5Yg=",
+      "dev": true,
+      "requires": {
+        "await-event": "^2.1.0",
+        "await-first": "^1.0.0",
+        "co": "^4.6.0",
+        "is-type-of": "^1.2.1"
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true
+    },
+    "sendmessage": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/sendmessage/download/sendmessage-1.1.0.tgz",
+      "integrity": "sha1-EKJFzuLVDHWfHgmiNHe5FJbQnjU=",
+      "dev": true
+    },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/sentence-case/download/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
+    "serialize-json": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/serialize-json/download/serialize-json-1.0.3.tgz",
+      "integrity": "sha1-4ECu7XZHl/w3TnhuxDi23zr/B6Q=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "is-type-of": "^1.2.1",
+        "utility": "^1.15.0"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/set-blocking/download/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npm.taobao.org/set-value/download/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/shebang-command/download/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/shebang-regex/download/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/signal-exit/download/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/slash/download/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/slice-ansi/download/slice-ansi-1.0.0.tgz",
+      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "smart-buffer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npm.taobao.org/smart-buffer/download/smart-buffer-4.0.2.tgz",
+      "integrity": "sha1-UgeFjDgVzGkRBwPGuU5GwVY0OV0=",
+      "dev": true
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "http://registry.npm.taobao.org/snake-case/download/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "http://registry.npm.taobao.org/snapdragon/download/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/snapdragon-node/download/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npm.taobao.org/snapdragon-util/download/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "socks": {
+      "version": "2.3.2",
+      "resolved": "http://registry.npm.taobao.org/socks/download/socks-2.3.2.tgz",
+      "integrity": "sha1-reOI6ebYf9sRZJwVdGxXiSKliD4=",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "4.0.2"
+      }
+    },
+    "socks-proxy-agent": {
+      "version": "4.0.2",
+      "resolved": "http://registry.npm.taobao.org/socks-proxy-agent/download/socks-proxy-agent-4.0.2.tgz",
+      "integrity": "sha1-PImR8xRbJ5nnDhG9X7yLGWMRY4Y=",
+      "dev": true,
+      "requires": {
+        "agent-base": "~4.2.1",
+        "socks": "~2.3.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npm.taobao.org/agent-base/download/agent-base-4.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fagent-base%2Fdownload%2Fagent-base-4.2.1.tgz",
+          "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "http://registry.npm.taobao.org/source-map-resolve/download/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha1-cuLMNAlVQ+Q7LGKyxMENSpBU8lk=",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.4.18.tgz",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "http://registry.npm.taobao.org/source-map-url/download/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/spdx-correct/download/spdx-correct-3.1.0.tgz",
+      "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "http://registry.npm.taobao.org/spdx-exceptions/download/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "http://registry.npm.taobao.org/spdx-expression-parse/download/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npm.taobao.org/spdx-license-ids/download/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+      "dev": true
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "http://registry.npm.taobao.org/split/download/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npm.taobao.org/split-string/download/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/sprintf-js/download/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "http://registry.npm.taobao.org/stack-trace/download/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/static-extend/download/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://registry.npm.taobao.org/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "http://registry.npm.taobao.org/statuses/download/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "http://registry.npm.taobao.org/stream-combiner/download/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "stream-slice": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/stream-slice/download/stream-slice-0.1.2.tgz",
+      "integrity": "sha1-LcT04bk2+xPz6zmi3vGTJ5jQeks=",
+      "dev": true
+    },
+    "stream-wormhole": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npm.taobao.org/stream-wormhole/download/stream-wormhole-1.1.0.tgz",
+      "integrity": "sha1-MAr/Rs7VU8/sZCoFJRiFQXaTwz0="
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "http://registry.npm.taobao.org/streamsearch/download/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-2.1.1.tgz",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "stringifier": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npm.taobao.org/stringifier/download/stringifier-1.4.0.tgz",
+      "integrity": "sha1-1wRYFWf0UmJl0A7Y7LNUoCw/7Cg=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.0.0",
+        "traverse": "^0.6.6",
+        "type-name": "^2.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "http://registry.npm.taobao.org/strip-ansi/download/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.taobao.org/strip-bom/download/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/strip-eof/download/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npm.taobao.org/strip-json-comments/download/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npm.taobao.org/superagent/download/superagent-3.8.3.tgz",
+      "integrity": "sha1-Rg6g29t9WxG8T3jeulZfhqF44Sg=",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz?cache=0&sync_timestamp=1562592096220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisarray%2Fdownload%2Fisarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-2.3.6.tgz",
+          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "4.0.2",
+      "resolved": "http://registry.npm.taobao.org/supertest/download/supertest-4.0.2.tgz",
+      "integrity": "sha1-wiNNvdbcebbxW5nI1ld7kOTOPzY=",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/swap-case/download/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npm.taobao.org/table/download/table-4.0.2.tgz?cache=0&sync_timestamp=1564593867491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftable%2Fdownload%2Ftable-4.0.2.tgz",
+      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fansi-styles%2Fdownload%2Fansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tcp-base": {
+      "version": "3.1.0",
+      "resolved": "http://registry.npm.taobao.org/tcp-base/download/tcp-base-3.1.0.tgz",
+      "integrity": "sha1-NUWL+MCiGgys9QkrTHWKU7OTF8E=",
+      "dev": true,
+      "requires": {
+        "is-type-of": "^1.0.0",
+        "sdk-base": "^3.1.1"
+      }
+    },
+    "tcp-proxy.js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npm.taobao.org/tcp-proxy.js/download/tcp-proxy.js-1.3.0.tgz",
+      "integrity": "sha1-EO1T41lCGAZmlr39tyAMKVEqp50=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.0.1",
+        "through2": "^2.0.3"
+      }
+    },
+    "test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npm.taobao.org/test-exclude/download/test-exclude-5.2.3.tgz",
+      "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      },
+      "dependencies": {
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "http://registry.npm.taobao.org/require-main-filename/download/require-main-filename-2.0.0.tgz",
+          "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "http://registry.npm.taobao.org/text-table/download/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "http://registry.npm.taobao.org/thenify/download/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.taobao.org/thenify-all/download/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npm.taobao.org/throat/download/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://registry.npm.taobao.org/through/download/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "http://registry.npm.taobao.org/through2/download/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz?cache=0&sync_timestamp=1562592096220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisarray%2Fdownload%2Fisarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.6.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freadable-stream%2Fdownload%2Freadable-stream-2.3.6.tgz",
+          "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "thunkify": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/thunkify/download/thunkify-2.1.2.tgz",
+      "integrity": "sha1-+qDp0jDFGsyVyhOjYawFyn4EVT0=",
+      "dev": true
+    },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/title-case/download/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "http://registry.npm.taobao.org/tmp/download/tmp-0.0.33.tgz",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "http://registry.npm.taobao.org/to-fast-properties/download/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "http://registry.npm.taobao.org/to-object-path/download/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://registry.npm.taobao.org/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "http://registry.npm.taobao.org/to-regex/download/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "http://registry.npm.taobao.org/extend-shallow/download/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://registry.npm.taobao.org/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "http://registry.npm.taobao.org/to-regex-range/download/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/toidentifier/download/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
+      "dev": true
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "http://registry.npm.taobao.org/traverse/download/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/trim-right/download/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npm.taobao.org/ts-node/download/ts-node-7.0.1.tgz",
+      "integrity": "sha1-lWLcLR5tJI0kvFX3c+P2FDN9m68=",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.13",
+          "resolved": "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.13.tgz",
+          "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/yn/download/yn-2.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyn%2Fdownload%2Fyn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+          "dev": true
+        }
+      }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npm.taobao.org/tslib/download/tslib-1.10.0.tgz",
+      "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
+      "dev": true
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.taobao.org/tsscmp/download/tsscmp-1.0.6.tgz",
+      "integrity": "sha1-hbmVg6w1iexL/vgltQAKqRHWBes=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npm.taobao.org/type/download/type-1.0.3.tgz",
+      "integrity": "sha1-FvXTnyei0o2G5I+JgYWenTKWwXk=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "http://registry.npm.taobao.org/type-check/download/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npm.taobao.org/type-is/download/type-is-1.6.18.tgz",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "type-name": {
+      "version": "2.0.2",
+      "resolved": "http://registry.npm.taobao.org/type-name/download/type-name-2.0.2.tgz",
+      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "http://registry.npm.taobao.org/typedarray/download/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npm.taobao.org/typescript/download/typescript-3.5.3.tgz?cache=0&sync_timestamp=1565704649916&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftypescript%2Fdownload%2Ftypescript-3.5.3.tgz",
+      "integrity": "sha1-yDD2V/k/HqhGgZ6SkJL1/lmD6Xc=",
+      "dev": true
+    },
+    "uid-safe": {
+      "version": "2.1.5",
+      "resolved": "http://registry.npm.taobao.org/uid-safe/download/uid-safe-2.1.5.tgz",
+      "integrity": "sha1-Kz1cckDo/C5Y+Komnl7knAhXvTo=",
+      "dev": true,
+      "requires": {
+        "random-bytes": "~1.0.0"
+      }
+    },
+    "unescape": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npm.taobao.org/unescape/download/unescape-1.0.1.tgz",
+      "integrity": "sha1-lW5DD2HK2KTVfYLFGPXmzF0N2pY=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1"
+      }
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npm.taobao.org/union-value/download/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "universal-deep-strict-equal": {
+      "version": "1.2.2",
+      "resolved": "http://registry.npm.taobao.org/universal-deep-strict-equal/download/universal-deep-strict-equal-1.2.2.tgz",
+      "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0",
+        "indexof": "0.0.1",
+        "object-keys": "^1.0.0"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/unpipe/download/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/unset-value/download/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "http://registry.npm.taobao.org/has-value/download/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npm.taobao.org/isobject/download/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "http://registry.npm.taobao.org/has-values/download/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz?cache=0&sync_timestamp=1562592096220&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fisarray%2Fdownload%2Fisarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/upath/download/upath-1.1.2.tgz",
+      "integrity": "sha1-PbZYYA7a7sy+bbXmhNZ+6MKs0Gg=",
+      "dev": true
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/upper-case/download/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/upper-case-first/download/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.1"
+      }
+    },
+    "urijs": {
+      "version": "1.19.1",
+      "resolved": "http://registry.npm.taobao.org/urijs/download/urijs-1.19.1.tgz",
+      "integrity": "sha1-Ww/1MMDL3oOG9jQiNbpcpumV0lo=",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "http://registry.npm.taobao.org/urix/download/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "urllib": {
+      "version": "2.34.0",
+      "resolved": "https://registry.npm.taobao.org/urllib/download/urllib-2.34.0.tgz",
+      "integrity": "sha1-kbxjDP3p3ZkL+0KumxqCx/at/hA=",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.3.0",
+        "content-type": "^1.0.2",
+        "debug": "^2.6.9",
+        "default-user-agent": "^1.0.0",
+        "digest-header": "^0.0.1",
+        "ee-first": "~1.1.1",
+        "formstream": "^1.1.0",
+        "humanize-ms": "^1.2.0",
+        "iconv-lite": "^0.4.15",
+        "ip": "^1.1.5",
+        "proxy-agent": "^3.1.0",
+        "pump": "^3.0.0",
+        "qs": "^6.4.0",
+        "statuses": "^1.3.1",
+        "utility": "^1.16.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "http://registry.npm.taobao.org/use/download/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utility": {
+      "version": "1.16.1",
+      "resolved": "http://registry.npm.taobao.org/utility/download/utility-1.16.1.tgz",
+      "integrity": "sha1-OD9ctjAEQUdnNxtJweSMoBniaw8=",
+      "dev": true,
+      "requires": {
+        "copy-to": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "mkdirp": "^0.5.1",
+        "mz": "^2.7.0",
+        "unescape": "^1.0.1"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "http://registry.npm.taobao.org/uuid/download/uuid-3.3.2.tgz",
+      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "http://registry.npm.taobao.org/validate-npm-package-license/download/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npm.taobao.org/vary/download/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "http://registry.npm.taobao.org/which/download/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "http://registry.npm.taobao.org/wide-align/download/wide-align-1.1.3.tgz",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/win-release/download/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "dev": true,
+      "requires": {
+        "semver": "^5.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npm.taobao.org/semver/download/semver-5.7.1.tgz?cache=0&sync_timestamp=1565627380363&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "http://registry.npm.taobao.org/window-size/download/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npm.taobao.org/wordwrap/download/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://registry.npm.taobao.org/wrappy/download/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "http://registry.npm.taobao.org/write/download/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "wt": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npm.taobao.org/wt/download/wt-1.2.0.tgz",
+      "integrity": "sha1-tMvjTB9QpWpUM6ndqMvbfGLjvN8=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "ndir": "^0.1.5",
+        "sdk-base": "^2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "get-ready": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/get-ready/download/get-ready-1.0.0.tgz",
+          "integrity": "sha1-+RgX8emt7P6hOlYq38jeiDqzR4I=",
+          "dev": true
+        },
+        "sdk-base": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npm.taobao.org/sdk-base/download/sdk-base-2.0.1.tgz",
+          "integrity": "sha1-ukAonovfJy7RHdnql+r5jgNtJMY=",
+          "dev": true,
+          "requires": {
+            "get-ready": "~1.0.0"
+          }
+        }
+      }
+    },
+    "xregexp": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/xregexp/download/xregexp-2.0.0.tgz",
+      "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
+      "dev": true
+    },
+    "xss": {
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.taobao.org/xss/download/xss-1.0.6.tgz",
+      "integrity": "sha1-6vEen8R2464omUShAJ793YoSS1E=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "cssfilter": "0.0.10"
+      }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npm.taobao.org/xtend/download/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "http://registry.npm.taobao.org/y18n/download/y18n-4.0.0.tgz",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "http://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "12.0.5",
+      "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-12.0.5.tgz",
+      "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-11.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-11.1.1.tgz",
+      "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npm.taobao.org/yargs-unparser/download/yargs-unparser-1.5.0.tgz?cache=0&sync_timestamp=1564464725506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-unparser%2Fdownload%2Fyargs-unparser-1.5.0.tgz",
+      "integrity": "sha1-8rsqfoPLyHu5XI5XKCigbJrdbg0=",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      }
+    },
+    "ylru": {
+      "version": "1.2.1",
+      "resolved": "http://registry.npm.taobao.org/ylru/download/ylru-1.2.1.tgz",
+      "integrity": "sha1-9Xa2M0FUeYnB3nuiiHYJI7J/6E8=",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npm.taobao.org/yn/download/yn-3.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyn%2Fdownload%2Fyn-3.1.1.tgz",
+      "integrity": "sha1-HodAGgnXZ8HV6rJqbkwYUYLS61A=",
+      "dev": true
+    },
+    "ypkgfiles": {
+      "version": "1.6.0",
+      "resolved": "http://registry.npm.taobao.org/ypkgfiles/download/ypkgfiles-1.6.0.tgz",
+      "integrity": "sha1-a65VZhYKbJNPVzUBmH9pFiRQY1E=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.1",
+        "glob": "^7.1.1",
+        "is-type-of": "^1.0.0",
+        "resolve-files": "^1.0.0",
+        "yargs": "^7.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "http://registry.npm.taobao.org/cliui/download/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npm.taobao.org/find-up/download/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/invert-kv/download/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/lcid/download/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npm.taobao.org/load-json-file/download/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npm.taobao.org/os-locale/download/os-locale-1.4.0.tgz?cache=0&sync_timestamp=1560274285880&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fos-locale%2Fdownload%2Fos-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "http://registry.npm.taobao.org/path-exists/download/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npm.taobao.org/path-type/download/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npm.taobao.org/read-pkg/download/read-pkg-1.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fread-pkg%2Fdownload%2Fread-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npm.taobao.org/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://registry.npm.taobao.org/string-width/download/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.taobao.org/strip-bom/download/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "http://registry.npm.taobao.org/which-module/download/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "http://registry.npm.taobao.org/y18n/download/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-5.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs-parser%2Fdownload%2Fyargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/onerror-custom-isProd/app/router.js
+++ b/test/fixtures/onerror-custom-isProd/app/router.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/500', function* () {
+    this.throw(500, 'hi, this custom 500 page');
+  });
+};

--- a/test/fixtures/onerror-custom-isProd/config/config.default.js
+++ b/test/fixtures/onerror-custom-isProd/config/config.default.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.onerror = {
+  isProd(app) { return app.env === 'prod'; },
+};
+
+exports.keys = 'foo,bar';
+
+exports.logger = {
+  level: 'NONE',
+  consoleLevel: 'NONE',
+};

--- a/test/fixtures/onerror-custom-isProd/package.json
+++ b/test/fixtures/onerror-custom-isProd/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "onerror-custom-isProd"
+}

--- a/test/onerror.test.js
+++ b/test/onerror.test.js
@@ -473,4 +473,36 @@ describe('test/onerror.test.js', () => {
     });
 
   });
+
+  describe('customize isProd detection', () => {
+
+    let app = null;
+    before(() => {
+      mm.consoleLevel('NONE');
+      app = mm.app({
+        baseDir: 'onerror-custom-isProd',
+      });
+      return app.ready();
+    });
+
+    after(() => app.close());
+
+    afterEach(mm.restore);
+
+    it('should show detail error information on non-prod env', () => {
+      mm(app.config, 'env', 'dev');
+      return app.httpRequest()
+        .get('/500')
+        .expect(/hi, this custom 500 page/)
+        .expect(500);
+    });
+
+    it('should hide detail error information on prod env', () => {
+      mm(app.config, 'env', 'prod');
+      return app.httpRequest()
+        .get('/500')
+        .expect('<h2>Internal Server Error, real status: 500</h2>')
+        .expect(500);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
在碰到错误时，有一个判断是否为生产环境的逻辑 isProd，目前不能被自定义。故添加了自定义这个逻辑的功能，望采纳！

默认逻辑是看 app.config.env，如果不是 local 或者 unittest，就认为是正式生产环境，然而多数现实情况下，除了 local 和 unittest ，还有多个环境，比如：
- dev
- test
- stage
- prod
- canary
- qa
等等。很可能我们希望 dev 和 test 不算作正式环境（可以暴露原始错误堆栈信息）。

通过允许在 `onerror` 配置中自定义这个逻辑，可以让以上需求实现起来比较简单。