### PR TITLE
feat: added display-errors & display-sections option

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,10 +54,19 @@ module.exports = app => {
         ? config.errorPageUrl(err, this)
         : config.errorPageUrl;
 
+      // If it's null, then use default isProd logic
+      let displayErrors = config.displayErrors === null ? !isProd(app) : config.displayErrors;
+
+      // It also can be a function
+      if (typeof displayErrors === 'function') {
+        displayErrors = displayErrors.call(app);
+      }
+
       // keep the real response status
       this.realStatus = status;
       // don't respond any error message in production env
-      if (isProd(app)) {
+      // if displayErrors set false, or unset, then use default logic
+      if (!displayErrors) {
         // 5xx
         if (status >= 500) {
           if (errorPageUrl) {

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -11,4 +11,10 @@ exports.onerror = {
   appErrorFilter: null,
   // default template path
   templatePath: path.join(__dirname, '../lib/onerror_page.mustache'),
+  // Set displayErrors to true, to display erros.
+  // If it's not set, then use the default isProd logic for it.
+  displayErrors: null,
+  // Sections you want to show in error page.
+  // Default to show all sections.
+  displaySections: [ 'CodeFrames', 'Headers', 'Cookies', 'AppInfo' ],
 };

--- a/lib/error_view.js
+++ b/lib/error_view.js
@@ -23,6 +23,7 @@ class ErrorView {
     this.app = ctx.app;
     this.assets = new Map();
     this.viewTemplate = template;
+    this.displaySections = this.app.config.onerror.displaySections;
   }
 
   /**
@@ -41,8 +42,14 @@ class ErrorView {
     });
 
     data.request = this.serializeRequest();
-    data.appInfo = this.serializeAppInfo();
 
+    if (this.displaySections.indexOf('AppInfo') > -1) {
+      data.appInfo = this.serializeAppInfo();
+    }
+
+    this.displaySections.forEach(item => {
+      data['display' + item + 'Section'] = true;
+    });
     return this.complieView(this.viewTemplate, data);
   }
 
@@ -240,13 +247,17 @@ class ErrorView {
     if (code) {
       message = `${message} (code: ${code})`;
     }
-    return {
+
+    const data = {
       code,
       message,
       name: this.error.name,
       status: this.error.status,
-      frames: stack instanceof Array ? stack.filter(frame => frame.getFileName()).map(frameFomatter) : [],
     };
+    if (this.displaySections.indexOf('CodeFrames') > -1) {
+      data.frames = stack instanceof Array ? stack.filter(frame => frame.getFileName()).map(frameFomatter) : [];
+    }
+    return data;
   }
 
   /**
@@ -257,31 +268,34 @@ class ErrorView {
    * @memberOf ErrorView
    */
   serializeRequest() {
-    const headers = [];
 
-    Object.keys(this.request.headers).forEach(key => {
-      if (this._filterHeaders.includes(key)) {
-        return;
-      }
-      headers.push({
-        key,
-        value: this.request.headers[key],
-      });
-    });
-
-    const parsedCookies = cookie.parse(this.request.headers.cookie || '');
-    const cookies = Object.keys(parsedCookies).map(key => {
-      return { key, value: parsedCookies[key] };
-    });
-
-    return {
+    const data = {
       url: this.request.url,
       httpVersion: this.request.httpVersion,
       method: this.request.method,
       connection: this.request.headers.connection,
-      headers,
-      cookies,
     };
+
+    if (this.displaySections.indexOf('Headers') > -1) {
+      const headers = [];
+      Object.keys(this.request.headers).forEach(key => {
+        if (this._filterHeaders.includes(key)) {
+          return;
+        }
+        headers.push({
+          key,
+          value: this.request.headers[key],
+        });
+      });
+      data.headers = headers;
+    }
+    if (this.displaySections.indexOf('Cookies') > -1) {
+      const parsedCookies = cookie.parse(this.request.headers.cookie || '');
+      data.cookies = Object.keys(parsedCookies).map(key => {
+        return { key, value: parsedCookies[key] };
+      });
+    }
+    return data;
   }
 
   /**

--- a/lib/onerror_page.mustache
+++ b/lib/onerror_page.mustache
@@ -580,6 +580,7 @@
 
       <img class="error-logo" src="https://zos.alipayobjects.com/rmsportal/JFKAMfmPehWfhBPdCjrw.svg"/>
 
+      {{#displayCodeFramesSection}}
       <div class="error-frames">
         <div class="frame-preview is-hidden">
           <div id="frame-file"></div>
@@ -593,8 +594,8 @@
             <label for="frames-filter">Show all frames</label>
           </div>
 
+          {{#frames}}
           <div class="frames-list">
-            {{#frames}}
               {{index}}
               <div class="frame-row {{classes}}">
                 <div class="frame-row-filepath">
@@ -619,8 +620,8 @@
           </div>
         </div>
       </div>
+      {{/displayCodeFramesSection}}
     </section>
-
     <section class="request-details">
       <h2 class="request-title"> Request Details </h2>
       <div class="table">
@@ -645,25 +646,33 @@
         </div>
       </div>
 
+
+      {{#displayHeadersSection}}
       <h2 class="request-title"> Headers </h2>
       <div class="table">
-        {{#request.headers}}
+          {{#request.headers}}
           <div class="tr">
             <div class="td title">{{ key }}</div>
             <div class="td content">{{ value }}</div>
           </div>
-        {{/request.headers}}
+          {{/request.headers}}
       </div>
+      {{/displayHeadersSection}}
 
+
+      {{#displayCookiesSection}}
       <h2 class="request-title"> Cookies </h2>
       <div class="table">
-        {{#request.cookies}}
+          {{#request.cookies}}
           <div class="tr">
             <div class="td title">{{ key }}</div>
             <div class="td content">{{ value }}</div>
           </div>
-        {{/request.cookies}}
+          {{/request.cookies}}
       </div>
+      {{/displayCookiesSection}}
+
+      {{#displayAppInfoSection}}
       <h2 class="request-title"> AppInfo </h2>
       <div class="table">
         <div class="tr">
@@ -676,7 +685,8 @@
             <pre class="line-numbers"><code class="language-json">{{ appInfo.config }}</code></pre>
           </div>
         </div>
-      </<div>
+      </div>
+      {{/displayAppInfoSection}}
     </section>
 
     <script type="text/javascript">

--- a/test/fixtures/onerror-display-error/app/extend/context.js
+++ b/test/fixtures/onerror-display-error/app/extend/context.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  get userId() {
+    throw new Error('you can`t get userId.');
+  },
+};

--- a/test/fixtures/onerror-display-error/app/router.js
+++ b/test/fixtures/onerror-display-error/app/router.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = app => {
+  app.get('/500', function* () {
+    this.throw(500, 'hi, this custom 500 page');
+  });
+};

--- a/test/fixtures/onerror-display-error/config/config.default.js
+++ b/test/fixtures/onerror-display-error/config/config.default.js
@@ -1,0 +1,6 @@
+'use strict';
+
+exports.keys = 'foo,bar';
+exports.onerror = {
+  displayErrors: process.env.SHOW_ERRORS - 1 === 0,
+};

--- a/test/fixtures/onerror-display-error/package.json
+++ b/test/fixtures/onerror-display-error/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "onerror-display-error"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows commit guidelines


##### Description of change
Similar to this PR: https://github.com/eggjs/egg-onerror/pull/30


**1. Added `displayErrors` option**
> I added a displayErrors option, (like php display_errors).  Because we can not say if env !== 'local' or env !== 'unittest' then env = 'prod', there are may test/uat...environments that we still need to show error stacks. I added this option so that we don't need to use env variable to see display errors or not. That's user behaviors. if they need to display errors in different env, then they can easily handle it in config files, like:

```
{
  displayErrors: process.env.NODE_ENV !== 'production'
}
```
or 
```
{
  displayErrors (app) => app.env !== 'prod'
}
```

**2. Added `displaySections` option**
> For some sections in error page, they are highly sensitive, like the appInfo section, or cookie section. Normally it contains the server side database password or user sensitive information. If we want to display errors in test/uat environment. then we should not to display those information to everybody. So I added this option. so that user can customize what section they want to show in the error pages